### PR TITLE
Release Workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Pre-Release
 
 # permissions:
 #   contents: write

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+# permissions:
+#   contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  package-crate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: sudo apt-get install -y libzmq3-dev
+      - run: sudo apt-get -y install libasound2-dev
+      - run: sudo apt-get -y install liblttng-ust-dev
+      - run: sudo apt-get -y install libsoapysdr-dev
+      - run: cargo publish --dry-run
+      - run: cargo package --list

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - chore/dist
 
 env: 
   CARGO_TERM_COLOR: always
@@ -14,6 +15,7 @@ env:
 jobs:
   package-crate:
     runs-on: ubuntu-latest
+    environment: cargo-crate-publish
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   package-crate:
     runs-on: ubuntu-latest
+    environment: cargo-crate-publish
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+# permissions:
+#   contents: write
+
+on:
+  push:
+    tags:
+      - '*-?v[0-9]+*'
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  package-crate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: sudo apt-get install -y libzmq3-dev
+      - run: sudo apt-get -y install libasound2-dev
+      - run: sudo apt-get -y install liblttng-ust-dev
+      - run: sudo apt-get -y install libsoapysdr-dev
+      - run: cargo publish   

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/futuresdr/fsdr-blocks/"
 description = "Building blocks for FutureSDR signal processing library for SDR and real-time DSP."
 keywords = ["sdr", "radio", "blocks", "iir", "fir", "async", "acceleration"]
 categories = ["asynchronous", "concurrency", "hardware-support", "science"]
-
+readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
I started to commit GitHub actions so as to automate the crate publishing.

@bastibl I do not have access to environment settings of this project.
So could you please either provide myself access to it, or add a crates.io TOKEN to it under `CARGO_REGISTRY_TOKEN`.

In case, of second option, you will later have to `cargo owner --add` @ratzrattillo  and myself please. Maybe also add the whole team?

The goal is to dry run the publication on commit in `main` branch, and to actually publish it on tagging.

