### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,22 +20,22 @@ members = [
 ]
 
 [dependencies]
-futuresdr = { git = "https://github.com/FutureSDR/FutureSDR", branch = "main", version = "0.0.37"}
-#futuresdr = { path = "../FutureSDR" }
-async-channel = { version = "2.3.1", optional = true }
-async-trait = "0.1.81"
-crossbeam-channel = { version = "0.5.13", optional = true }
-bimap = { version = "0.6.3", optional = true }
-sigmf = { version = "0.1.0", path = "crates/sigmf" }
-async-fs = "2.1.2"
-serde = "1.0.204"
+futuresdr = { git = "https://github.com/FutureSDR/FutureSDR", branch = "main", version = "0.0.40-dev"}
+# futuresdr = { path = "../FutureSDR" }
+async-channel = { version = "2.5", optional = true }
+async-trait = "0.1"
+crossbeam-channel = { version = "0.5", optional = true }
+bimap = { version = "0.6", optional = true }
+sigmf = { version = "0.1", path = "crates/sigmf" }
+async-fs = "2.2"
+serde = "1.0"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", features = ["html_reports"] }
-tokio-test = "0.4.4"
-rand = { version = "0.8.5" }
+criterion = { version = "0.8", features = ["html_reports"] }
+tokio-test = "0.4"
+rand = { version = "0.10" }
 quickcheck_macros = "1"
-serde_json = "1.0.120"
+serde_json = "1.0"
 
 [features]
 default = []


### PR DESCRIPTION
Update dependencies.
This is the base for getting all the blocks updated to work with the latest FutureSDR version 0.0.40-dev