### PR TITLE
chore: Migration of 0.0.40-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,9 @@ members = [
 ]
 
 [dependencies]
-futuresdr = { git = "https://github.com/FutureSDR/FutureSDR", branch = "main", version = "0.0.37"}
+futuresdr = { git = "https://github.com/FutureSDR/FutureSDR", branch = "main", version = "0.0.40-dev"}
 #futuresdr = { path = "../FutureSDR" }
 async-channel = { version = "2.3.1", optional = true }
-async-trait = "0.1.81"
 crossbeam-channel = { version = "0.5.13", optional = true }
 bimap = { version = "0.6.3", optional = true }
 sigmf = { version = "0.1.0", path = "crates/sigmf" }

--- a/crates/sigmf-utilities/src/sigmf_col.rs
+++ b/crates/sigmf-utilities/src/sigmf_col.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::{arg, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use sigmf::{DescriptionBuilder, RecordingBuilder};
 use std::path::PathBuf;
 

--- a/crates/sigmf-utilities/src/sigmf_convert.rs
+++ b/crates/sigmf-utilities/src/sigmf_convert.rs
@@ -1,5 +1,5 @@
 use anyhow::anyhow;
-use clap::{arg, Parser};
+use clap::Parser;
 use fsdr_blocks::sigmf::DatasetFormat;
 use fsdr_blocks::sigmf::DatasetFormat::*;
 use fsdr_blocks::sigmf::{SigMFSinkBuilder, SigMFSourceBuilder};
@@ -27,45 +27,44 @@ impl Cli {
     pub async fn execute(self) -> Result<()> {
         let mut fg = Flowgraph::new();
 
-        let mut src = SigMFSourceBuilder::from(&self.input);
-        let src = src.build::<f32>().await?;
+        let mut src_builder = SigMFSourceBuilder::from(&self.input);
+        let src = fg.add_block(src_builder.build::<f32>().await?);
 
         let snk = SigMFSinkBuilder::from(self.output);
 
-        let (conv, snk) = match self.target {
-            RI8 => (
-                TypeConvertersBuilder::lossy_scale_convert_f32_i8().build(),
-                snk.datatype(self.target).build::<i8>().await?,
-            ),
-            RU8 => (
-                TypeConvertersBuilder::lossy_scale_convert_f32_u8().build(),
-                snk.datatype(self.target).build::<u8>().await?,
-            ),
-            Rf32Be | Rf32Le => (
-                Apply::new(|x: &f32| *x).into(),
-                snk.datatype(self.target).build::<f32>().await?,
-            ),
-            Rf64Be | Rf64Le => (
-                TypeConvertersBuilder::convert::<f32, f64>().build(),
-                snk.datatype(self.target).build::<f64>().await?,
-            ),
-            Ri16Be | Ri16Le => (
-                TypeConvertersBuilder::lossy_scale_convert_f32_i16().build(),
-                snk.datatype(self.target).build::<i16>().await?,
-            ),
-            // Ri32Be | Ri32Le  => (
-            //     fg.add_block(TypeConvertersBuilder::lossy_scale_convert_f32_i32().build()),
-            //     fg.add_block(snk.datatype(self.target).build::<i32>().await?),
-            // ),
-            // Ru16Be | Ru16Le  => {
-            //     fg.add_block(TypeConvertersBuilder::convert::<f32, u16>().build())
-            // }
-            // Ru32Be | Ru32Le  => {
-            //     fg.add_block(TypeConvertersBuilder::convert::<f32, u32>().build())
-            // }
+        match self.target {
+            RI8 => {
+                let conv = TypeConvertersBuilder::lossy_scale_convert_f32_i8().build();
+                let snk = snk.datatype(self.target).build::<i8>().await?;
+                let src_ref = src.clone();
+                connect!(fg, src_ref > conv > snk);
+            }
+            RU8 => {
+                let conv = TypeConvertersBuilder::lossy_scale_convert_f32_u8().build();
+                let snk = snk.datatype(self.target).build::<u8>().await?;
+                let src_ref = src.clone();
+                connect!(fg, src_ref > conv > snk);
+            }
+            Rf32Be | Rf32Le => {
+                let conv: Apply<fn(&f32) -> f32, f32, f32> = Apply::new(|x: &f32| *x);
+                let snk = snk.datatype(self.target).build::<f32>().await?;
+                let src_ref = src.clone();
+                connect!(fg, src_ref > conv > snk);
+            }
+            Rf64Be | Rf64Le => {
+                let conv = TypeConvertersBuilder::convert::<f32, f64>().build();
+                let snk = snk.datatype(self.target).build::<f64>().await?;
+                let src_ref = src.clone();
+                connect!(fg, src_ref > conv > snk);
+            }
+            Ri16Be | Ri16Le => {
+                let conv = TypeConvertersBuilder::lossy_scale_convert_f32_i16().build();
+                let snk = snk.datatype(self.target).build::<i16>().await?;
+                let src_ref = src.clone();
+                connect!(fg, src_ref > conv > snk);
+            }
             _ => return Err(anyhow!("Unsupported target type: {}", self.target)),
         };
-        connect!(fg, src > conv > snk);
         // fg.connect_stream(src, "out", conv, "in")
         //     .with_context(|| "src->conv")?;
         // fg.connect_stream(conv, "out", snk, "in")

--- a/crates/sigmf-utilities/src/sigmf_hash.rs
+++ b/crates/sigmf-utilities/src/sigmf_hash.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use clap::{arg, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use sigmf::RecordingBuilder;
 use std::path::PathBuf;
 

--- a/src/agc.rs
+++ b/src/agc.rs
@@ -1,4 +1,3 @@
-use futuresdr::macros::message_handler;
 use futuresdr::num_complex::ComplexFloat;
 use futuresdr::prelude::*;
 
@@ -62,7 +61,6 @@ where
         }
     }
 
-    #[message_handler]
     async fn auto_lock(
         &mut self,
         _io: &mut WorkIo,
@@ -78,7 +76,6 @@ where
         }
     }
 
-    #[message_handler]
     async fn gain_lock(
         &mut self,
         _io: &mut WorkIo,
@@ -94,7 +91,6 @@ where
         }
     }
 
-    #[message_handler]
     async fn max_gain(
         &mut self,
         _io: &mut WorkIo,
@@ -110,7 +106,6 @@ where
         }
     }
 
-    #[message_handler]
     async fn adjustment_rate(
         &mut self,
         _io: &mut WorkIo,
@@ -126,7 +121,6 @@ where
         }
     }
 
-    #[message_handler]
     async fn reference_power(
         &mut self,
         _io: &mut WorkIo,

--- a/src/agc.rs
+++ b/src/agc.rs
@@ -1,34 +1,19 @@
 use futuresdr::macros::message_handler;
 use futuresdr::num_complex::ComplexFloat;
-use futuresdr::runtime::Block;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Pmt;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-
-/* #[cfg(feature = "telemetry")]
-use {
-    std::sync::LazyLock, telemetry::opentelemetry::global,
-    telemetry::opentelemetry::metrics::Gauge, telemetry::opentelemetry::KeyValue,
-};
-
-#[cfg(feature = "telemetry")]
-static AGC_GAUGE: LazyLock<Gauge<f64>> = LazyLock::new(|| {
-    global::meter("AGC_METER")
-        .f64_gauge("agc_gauge")
-        .with_description("Gauge to measure AGC parameters")
-        .with_unit("dB")
-        .init()
-}); */
+use futuresdr::prelude::*;
 
 /// Automatic Gain Control Block
-pub struct Agc<T> {
+#[derive(Block)]
+#[message_inputs(auto_lock, gain_lock, max_gain, adjustment_rate, reference_power)]
+pub struct Agc<
+    T: Send + Sync + ComplexFloat + Default + std::fmt::Debug + 'static,
+    I: CpuBufferReader<Item = T> = DefaultCpuReader<T>,
+    O: CpuBufferWriter<Item = T> = DefaultCpuWriter<T>,
+> {
+    #[input]
+    input: I,
+    #[output]
+    output: O,
     /// Minimum value that has to be reached in order for AGC to start adjusting gain.
     squelch: f32,
     /// maximum gain value
@@ -43,37 +28,15 @@ pub struct Agc<T> {
     gain_lock: bool,
     /// Set when gain should be automatically locked, when reference power is reached.
     auto_lock: bool,
-    _type: std::marker::PhantomData<T>,
 }
 
-impl<T> Agc<T>
+impl<T, I, O> Agc<T, I, O>
 where
-    T: Send + Sync + ComplexFloat + 'static,
+    T: Send + Sync + ComplexFloat + Default + std::fmt::Debug + 'static,
+    I: CpuBufferReader<Item = T>,
+    O: CpuBufferWriter<Item = T>,
 {
     /// Create AGC Block
-    ///
-    /// ## Parameter
-    /// - `squelch`: surpress anything below this level
-    /// - `max_gain`: maximum gain setting
-    /// - `gain`: initial gain setting
-    /// - `reference_power`: target power level
-    /// - `gain_lock`: lock gain to fixed value
-    /// - `auto_lock`: lock gain, when reference power is reached
-    ///
-    /// ## Message Handler
-    ///
-    /// - `auto_lock`: set `auto_lock` parameter with a [`Pmt::Bool`].
-    /// - `gain_lock`: set `gain_lock` parameter with a [`Pmt::Bool`].
-    /// - `max_gain`: set `max_gain` parameter with a [`Pmt::F32`].
-    /// - `adjustment_rate`: set `adjustment_rate` with a [`Pmt::F32`].
-    /// - `reference_power`: set `reference_power` with a [`Pmt::F32`].
-    ///
-    /// ## Stream Input
-    /// - `in`: Input stream of items, implementing [`ComplexFloat`]
-    ///
-    /// ## Stream Output
-    /// - `out`: Leveled output items of same type as `in` stream.
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         squelch: f32,
         max_gain: f32,
@@ -82,41 +45,28 @@ where
         reference_power: f32,
         gain_lock: bool,
         auto_lock: bool,
-    ) -> Block {
+    ) -> Self {
         assert!(max_gain >= 0.0);
         assert!(squelch >= 0.0);
 
-        Block::new(
-            BlockMetaBuilder::new("AGC").build(),
-            StreamIoBuilder::new()
-                .add_input::<T>("in")
-                .add_output::<T>("out")
-                .build(),
-            MessageIoBuilder::<Self>::new()
-                .add_input("auto_lock", Self::auto_lock)
-                .add_input("gain_lock", Self::gain_lock)
-                .add_input("max_gain", Self::max_gain)
-                .add_input("adjustment_rate", Self::adjustment_rate)
-                .add_input("reference_power", Self::reference_power)
-                .build(),
-            Agc {
-                squelch,
-                max_gain,
-                gain,
-                reference_power,
-                adjustment_rate,
-                gain_lock,
-                auto_lock,
-                _type: std::marker::PhantomData,
-            },
-        )
+        Agc {
+            input: I::default(),
+            output: O::default(),
+            squelch,
+            max_gain,
+            gain,
+            reference_power,
+            adjustment_rate,
+            gain_lock,
+            auto_lock,
+        }
     }
 
     #[message_handler]
     async fn auto_lock(
         &mut self,
         _io: &mut WorkIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
         p: Pmt,
     ) -> Result<Pmt> {
@@ -132,7 +82,7 @@ where
     async fn gain_lock(
         &mut self,
         _io: &mut WorkIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
         p: Pmt,
     ) -> Result<Pmt> {
@@ -148,7 +98,7 @@ where
     async fn max_gain(
         &mut self,
         _io: &mut WorkIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
         p: Pmt,
     ) -> Result<Pmt> {
@@ -164,7 +114,7 @@ where
     async fn adjustment_rate(
         &mut self,
         _io: &mut WorkIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
         p: Pmt,
     ) -> Result<Pmt> {
@@ -180,7 +130,7 @@ where
     async fn reference_power(
         &mut self,
         _io: &mut WorkIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
         p: Pmt,
     ) -> Result<Pmt> {
@@ -191,118 +141,77 @@ where
             Ok(Pmt::InvalidValue)
         }
     }
-
-    #[inline(always)]
-    fn scale(&mut self, input: T) -> T {
-        let output = input * T::from(self.gain).unwrap();
-        // if the input power is very low or very high compared to the reference power, we still want to reach the reference power quickly.
-        // Thus we should make the gain also dependent on the input_power in relation to the reference power.
-
-        // Gain is only exactly 1.0 when the AGC block is freshly initialized
-        // We then can set the gain to a suitable value to scale
-        // the input power to e.g. 99% of the reference power immediately.
-        // if self.gain == 1.0 {
-        //     self.gain = (self.reference_power / input.abs().to_f32().unwrap()) * 0.99;
-        // }
-
-        // The gain adjustment rate should not be fixed, but depending
-        // on the input power in relation to the reference power (Thus actually the gain).
-        // We dont want the gain to be adjusted very strongly on rather weak signals,
-        // as it might make them being flattened out after a short time.
-        // Thus, if we have a high gain factor ( a multitude of 1.0 or very close to zero) -> log10(gain).abs() is:
-        //   - getting closer to zero, we want bigger changes -> higher adjustment_rate value
-        //   - getting bigger, we want smaller changes -> smaller adjustment_rate value
-        let dynamic_adjustment_rate = self.adjustment_rate.powf(self.gain.log10().abs());
-
-        let output_power = output.to_f32().unwrap().powi(2);
-
-        if self.auto_lock && !self.gain_lock {
-            let input_power = input.to_f32().unwrap().powi(2);
-            // Two scenarios exist here:
-            if input_power > self.reference_power {
-                // 1. Input power is greater than reference power (We are scaling the signal down)
-                //    - As soon as the output power is smaller than the reference power, we lock the gain.
-                if output_power < self.reference_power {
-                    self.gain_lock = true;
-                    //debug!("Locked gain at at {}", self.gain)
-                }
-            } else {
-                // 2. Input power is smaller than reference power (We are scaling the signal up)
-                //    - As soon as the output power is greater than the reference power, we lock the gain.
-                if output_power > self.reference_power {
-                    self.gain_lock = true;
-                    //debug!("Locked gain at at {}", self.gain)
-                }
-            }
-        }
-
-        if !self.gain_lock {
-            // Slow down AGC adjustments 1/adjustment_rate times
-            self.gain *=
-                1.0 + (self.reference_power / output_power).log10() * dynamic_adjustment_rate;
-        }
-        output
-    }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T> Kernel for Agc<T>
+impl<T, I, O> Kernel for Agc<T, I, O>
 where
-    T: Send + Sync + ComplexFloat + 'static,
+    T: Send + Sync + ComplexFloat + Default + std::fmt::Debug + std::marker::Copy + 'static,
+    I: CpuBufferReader<Item = T>,
+    O: CpuBufferWriter<Item = T>,
 {
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<T>();
-        let o = sio.output(0).slice::<T>();
+        let m = {
+            let i = self.input.slice();
+            let o = self.output.slice();
 
-        let m = std::cmp::min(i.len(), o.len());
-        if m > 0 {
-            for (src, dst) in i.iter().zip(o.iter_mut()) {
-                let input_power = src.to_f32().unwrap().powi(2);
-                if input_power > self.squelch {
-                    *dst = self.scale(*src);
-                } else {
-                    *dst = T::from(0.0).unwrap();
+            let m = std::cmp::min(i.len(), o.len());
+            if m > 0 {
+                let squelch = self.squelch;
+                let mut gain = self.gain;
+                let mut gain_lock = self.gain_lock;
+                let auto_lock = self.auto_lock;
+                let reference_power = self.reference_power;
+                let adjustment_rate = self.adjustment_rate;
+
+                for (src, dst) in i[..m].iter().zip(o[..m].iter_mut()) {
+                    let input_power = src.to_f32().unwrap().powi(2);
+                    if input_power > squelch {
+                        let output = (*src) * T::from(gain).unwrap();
+                        let output_power = output.to_f32().unwrap().powi(2);
+
+                        if auto_lock {
+                            if input_power > reference_power {
+                                if output_power < reference_power {
+                                    gain_lock = true;
+                                }
+                            } else if output_power > reference_power {
+                                gain_lock = true;
+                            }
+                        }
+
+                        if !gain_lock {
+                            let dynamic_adjustment_rate = if adjustment_rate > 0.0 {
+                                adjustment_rate
+                            } else {
+                                0.0001
+                            };
+                            gain *= 1.0
+                                + (reference_power / output_power).log10()
+                                    * dynamic_adjustment_rate;
+                        }
+                        *dst = output;
+                    } else {
+                        *dst = T::from(0.0).unwrap();
+                    }
                 }
-
-                /* #[cfg(feature = "telemetry")]
-                if _meta.telemetry_config().active_metrics().contains("agc") {
-                    // info!("Collecting AGC telemetry data");
-                    AGC_GAUGE.record(input_power.into(), &[KeyValue::new("type", "input_power")]);
-                    let output_power = (*dst).to_f32().unwrap().powi(2);
-                    AGC_GAUGE.record(
-                        output_power.into(),
-                        &[KeyValue::new("type", "output_power")],
-                    );
-                    // We need a force_flush() here on the meter_provider to record the exact values and dont aggregate them over time.
-                    // Might have to wait for implementation here: https://github.com/open-telemetry/opentelemetry-specification/issues/617
-                    let _ = futuresdr::runtime::METER_PROVIDER.force_flush();
-                } */
+                self.gain = gain;
+                self.gain_lock = gain_lock;
             }
+            m
+        };
 
-            /* #[cfg(feature = "telemetry")]
-            if _meta.telemetry_config().active_metrics().contains("agc") {
-                AGC_GAUGE.record(self.squelch.into(), &[KeyValue::new("type", "squelch")]);
-                AGC_GAUGE.record(
-                    self.reference_power.into(),
-                    &[KeyValue::new("type", "reference_power")],
-                );
-                // We need a force_flush() here on the meter_provider to record the exact values and dont aggregate them over time.
-                // Might have to wait for implementation here: https://github.com/open-telemetry/opentelemetry-specification/issues/617
-                let _ = futuresdr::runtime::METER_PROVIDER.force_flush();
-            } */
-
-            sio.input(0).consume(m);
-            sio.output(0).produce(m);
+        if m > 0 {
+            self.input.consume(m);
+            self.output.produce(m);
         }
 
-        if sio.input(0).finished() && m == i.len() {
+        if self.input.finished() && self.input.slice().is_empty() {
             io.finished = true;
         }
 
@@ -311,10 +220,7 @@ where
 }
 
 /// Builder for [`Agc`] block
-pub struct AgcBuilder<T>
-where
-    T: Send + Sync + ComplexFloat + 'static,
-{
+pub struct AgcBuilder<T> {
     squelch: f32,
     /// maximum gain value (0 for unlimited).
     max_gain: f32,
@@ -333,7 +239,7 @@ where
 
 impl<T> AgcBuilder<T>
 where
-    T: Send + Sync + ComplexFloat + 'static,
+    T: Send + Sync + ComplexFloat + Default + std::fmt::Debug + 'static,
 {
     /// Create builder w/ default parameters
     ///
@@ -395,7 +301,7 @@ where
     }
 
     /// Create [`Agc`] block
-    pub fn build(self) -> Block {
+    pub fn build(self) -> Agc<T> {
         Agc::<T>::new(
             self.squelch,
             self.max_gain,
@@ -408,7 +314,9 @@ where
     }
 }
 
-impl<T: ComplexFloat + Send + Sync> Default for AgcBuilder<T> {
+impl<T: Send + Sync + ComplexFloat + Default + std::fmt::Debug + 'static> Default
+    for AgcBuilder<T>
+{
     fn default() -> Self {
         Self::new()
     }

--- a/src/async_channel/async_channel_sink.rs
+++ b/src/async_channel/async_channel_sink.rs
@@ -1,65 +1,67 @@
 use async_channel::Sender;
+use futuresdr::prelude::*;
 
-use futuresdr::runtime::Block;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-
-/// Get samples out of a Flowgraph into a channel.
+/// Push samples originating from a stream in a flowgraph into an async channel.
 ///
 /// # Inputs
 ///
-/// `in`: Samples retrieved from teh flowgraph
+/// `in`: Samples pushed into the channel
 ///
 /// # Usage
 /// ```
 /// use async_channel;
+/// use fsdr_blocks::async_channel::AsyncChannelSink;
+/// use futuresdr::prelude::*;
 /// use futuresdr::blocks::VectorSource;
-/// use fsdr-blocks::blocks::AsyncChannelSink
-/// use futuresdr::runtime::Flowgraph;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut fg = Flowgraph::new();
-/// let (tx, rx) = async_channel::unbounded::<Box<[u32]>>();
-/// let vec = vec![0, 1, 2];
-/// let src = fg.add_block(VectorSource::<u32>::new(vec));
-/// let cs = fg.add_block(AsyncChannelSink::<u32>::new(tx));
-/// // start flowgraph
+/// let (tx, rx) = async_channel::unbounded::<Box<[f32]>>();
+///
+/// let orig: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+/// let src = VectorSource::<f32>::new(orig.clone());
+/// let snk = AsyncChannelSink::<f32>::new(tx.clone());
+///
+/// connect!(fg, src > snk);
+/// Runtime::new().run(fg)?;
+///
+/// assert_eq!(orig, futuresdr::async_io::block_on(rx.recv()).unwrap().to_vec());
+/// # Ok(())
+/// # }
 /// ```
-pub struct AsyncChannelSink<T: Send + 'static> {
+#[derive(Block)]
+pub struct AsyncChannelSink<
+    T: Send + Sync + Clone + 'static,
+    I: CpuBufferReader<Item = T> = DefaultCpuReader<T>,
+> {
+    #[input]
+    input: I,
     sender: Sender<Box<[T]>>,
 }
 
-impl<T: Send + Clone + 'static> AsyncChannelSink<T> {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(sender: Sender<Box<[T]>>) -> Block {
-        Block::new(
-            BlockMetaBuilder::new("AsyncChannelSink").build(),
-            StreamIoBuilder::new().add_input::<T>("in").build(),
-            MessageIoBuilder::new().build(),
-            AsyncChannelSink::<T> { sender },
-        )
+impl<T: Send + Sync + Clone + 'static, I: CpuBufferReader<Item = T>> AsyncChannelSink<T, I> {
+    pub fn new(sender: Sender<Box<[T]>>) -> Self {
+        AsyncChannelSink {
+            input: I::default(),
+            sender,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T: Send + Clone + 'static> Kernel for AsyncChannelSink<T> {
+impl<T: Send + Sync + Clone + 'static, I: CpuBufferReader<Item = T>> Kernel
+    for AsyncChannelSink<T, I>
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<T>();
+        let i = self.input.slice();
 
-        if !i.is_empty() {
+        let i_len = i.len();
+        if i_len > 0 {
             match self.sender.try_send(i.into()) {
                 Ok(_) => {
                     // info!("sent data...");
@@ -68,10 +70,10 @@ impl<T: Send + Clone + 'static> Kernel for AsyncChannelSink<T> {
                     // info!("{}", err.to_string());
                 }
             }
-            sio.input(0).consume(i.len());
+            self.input.consume(i_len);
         }
 
-        if sio.input(0).finished() {
+        if self.input.finished() {
             io.finished = true;
         }
 

--- a/src/async_channel/async_channel_source.rs
+++ b/src/async_channel/async_channel_source.rs
@@ -1,16 +1,5 @@
 use async_channel::Receiver;
-use futuresdr::futures::StreamExt;
-
-use futuresdr::runtime::Block;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
+use futuresdr::prelude::*;
 
 /// Push samples through a channel into a stream connection.
 ///
@@ -21,7 +10,7 @@ use futuresdr::runtime::WorkIo;
 /// # Usage
 /// ```
 /// use async_channel;
-/// use fsdr-blocks::blocks::AsyncChannelSource;
+/// use fsdr_blocks::async_channel::AsyncChannelSource;
 /// use futuresdr::runtime::Flowgraph;
 ///
 /// let mut fg = Flowgraph::new();
@@ -29,72 +18,83 @@ use futuresdr::runtime::WorkIo;
 ///
 /// let async_channel_src = fg.add_block(AsyncChannelSource::<u32>::new(rx));
 ///
-/// tx.send(orig.clone().into_boxed_slice()).await.unwrap();
+/// // tx.send(orig.clone().into_boxed_slice()).await.unwrap();
 /// ```
-pub struct AsyncChannelSource<T: Send + 'static> {
+#[derive(Block)]
+pub struct AsyncChannelSource<
+    T: Send + Sync + Default + Clone + Copy + std::fmt::Debug + 'static,
+    O: CpuBufferWriter<Item = T> = DefaultCpuWriter<T>,
+> {
+    #[output]
+    output: O,
     receiver: Receiver<Box<[T]>>,
     current: Option<(Box<[T]>, usize)>,
 }
 
-impl<T: Send + 'static> AsyncChannelSource<T> {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(receiver: Receiver<Box<[T]>>) -> Block {
-        Block::new(
-            BlockMetaBuilder::new("AsyncChannelSource").build(),
-            StreamIoBuilder::new().add_output::<T>("out").build(),
-            MessageIoBuilder::new().build(),
-            AsyncChannelSource::<T> {
-                receiver,
-                current: None,
-            },
-        )
+impl<
+        T: Send + Sync + Default + Clone + Copy + std::fmt::Debug + 'static,
+        O: CpuBufferWriter<Item = T>,
+    > AsyncChannelSource<T, O>
+{
+    pub fn new(receiver: Receiver<Box<[T]>>) -> Self {
+        AsyncChannelSource {
+            output: O::default(),
+            receiver,
+            current: None,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T: Send + 'static> Kernel for AsyncChannelSource<T> {
+impl<T, O> Kernel for AsyncChannelSource<T, O>
+where
+    T: Send + Sync + Default + Clone + Copy + std::fmt::Debug + 'static,
+    O: CpuBufferWriter<Item = T>,
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let out = sio.output(0).slice::<T>();
-        if out.is_empty() {
-            return Ok(());
-        }
+        let (produced, call_again, finished) = {
+            let out = self.output.slice();
+            if out.is_empty() {
+                return Ok(());
+            }
 
-        if self.current.is_none() {
-            match self.receiver.by_ref().recv().await {
-                //.by_ref().next().await
-                Ok(data) => {
-                    // info!("received data chunk on channel");
-                    self.current = Some((data, 0));
-                }
-                Err(_err) => {
-                    // info!("sender-end of channel was closed");
-                    io.finished = true;
-                    return Ok(());
+            let mut finished = false;
+            if self.current.is_none() {
+                match self.receiver.try_recv() {
+                    Ok(data) => {
+                        self.current = Some((data, 0));
+                    }
+                    Err(async_channel::TryRecvError::Empty) => {}
+                    Err(async_channel::TryRecvError::Closed) => {
+                        finished = true;
+                    }
                 }
             }
-        }
 
-        if let Some((data, index)) = &mut self.current {
-            let n = std::cmp::min(data.len() - *index, out.len());
-            unsafe {
-                std::ptr::copy_nonoverlapping(data.as_ptr().add(*index), out.as_mut_ptr(), n);
-            };
-            sio.output(0).produce(n);
-            *index += n;
-            if *index == data.len() {
-                self.current = None;
+            let mut produced = 0;
+            if let Some((data, index)) = &mut self.current {
+                let n = std::cmp::min(data.len() - *index, out.len());
+                out[..n].copy_from_slice(&data[*index..*index + n]);
+                produced = n;
+                *index += n;
+                if *index == data.len() {
+                    self.current = None;
+                }
             }
-        }
+            (produced, self.current.is_none(), finished)
+        };
 
-        if self.current.is_none() {
-            io.call_again = true;
+        if produced > 0 {
+            self.output.produce(produced);
+        }
+        io.call_again = call_again;
+        if finished {
+            io.finished = true;
         }
 
         Ok(())

--- a/src/channel/crossbeam_sink.rs
+++ b/src/channel/crossbeam_sink.rs
@@ -1,15 +1,5 @@
-use async_trait::async_trait;
 use crossbeam_channel::Sender;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-use futuresdr::runtime::{Block, TypedBlock};
+use futuresdr::prelude::*;
 
 /// Push samples originating from a stream in a flowgraph into a crossbeam channel.
 ///
@@ -21,54 +11,55 @@ use futuresdr::runtime::{Block, TypedBlock};
 /// ```
 /// use crossbeam_channel;
 /// use fsdr_blocks::channel::CrossbeamSink;
+/// use futuresdr::prelude::*;
 /// use futuresdr::blocks::VectorSource;
-/// use futuresdr::runtime::{Flowgraph, Runtime};
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut fg = Flowgraph::new();
 /// let (tx, rx) = crossbeam_channel::unbounded::<Box<[f32]>>();
 ///
 /// let orig: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
-/// let vector_src = fg.add_block(VectorSource::<f32>::new(orig.clone()));
-/// let crossbeam_sink = fg.add_block(CrossbeamSink::<f32>::new(tx.clone()));
+/// let src = VectorSource::<f32>::new(orig.clone());
+/// let snk = CrossbeamSink::<f32>::new(tx.clone());
 ///
-/// fg.connect_stream(vector_src, "out", crossbeam_sink, "in").unwrap();
-/// Runtime::new().run(fg).unwrap();
+/// connect!(fg, src > snk);
+/// Runtime::new().run(fg)?;
 ///
 /// assert_eq!(orig, rx.recv().unwrap().to_vec());
+/// # Ok(())
+/// # }
 /// ```
-pub struct CrossbeamSink<T: Send + Copy + 'static> {
+#[derive(Block)]
+pub struct CrossbeamSink<
+    T: Send + Sync + Copy + 'static,
+    I: CpuBufferReader<Item = T> = DefaultCpuReader<T>,
+> {
+    #[input]
+    input: I,
     sender: Sender<Box<[T]>>,
 }
 
-impl<T: Send + Copy + 'static> CrossbeamSink<T> {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(sender: Sender<Box<[T]>>) -> Block {
-        Block::from_typed(Self::new_typed(sender))
-    }
-
-    pub fn new_typed(sender: Sender<Box<[T]>>) -> TypedBlock<Self> {
-        TypedBlock::new(
-            BlockMetaBuilder::new("CrossbeamSink").build(),
-            StreamIoBuilder::new().add_input::<T>("in").build(),
-            MessageIoBuilder::<Self>::new().build(),
-            CrossbeamSink::<T> { sender },
-        )
+impl<T: Send + Sync + Copy + 'static, I: CpuBufferReader<Item = T>> CrossbeamSink<T, I> {
+    pub fn new(sender: Sender<Box<[T]>>) -> Self {
+        CrossbeamSink {
+            input: I::default(),
+            sender,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T: Send + Copy + 'static> Kernel for CrossbeamSink<T> {
+impl<T: Send + Sync + Copy + 'static, I: CpuBufferReader<Item = T>> Kernel for CrossbeamSink<T, I> {
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<T>();
+        let i = self.input.slice();
 
-        if !i.is_empty() {
+        let i_len = i.len();
+        if i_len > 0 {
             match self.sender.try_send(i.into()) {
                 Ok(_) => {
                     //info!("sent data...");
@@ -77,10 +68,10 @@ impl<T: Send + Copy + 'static> Kernel for CrossbeamSink<T> {
                     //info!("{}", err.to_string());
                 }
             }
-            sio.input(0).consume(i.len());
+            self.input.consume(i_len);
         }
 
-        if sio.input(0).finished() {
+        if self.input.finished() {
             io.finished = true;
         }
 

--- a/src/channel/crossbeam_source.rs
+++ b/src/channel/crossbeam_source.rs
@@ -1,128 +1,107 @@
-use async_trait::async_trait;
-use crossbeam_channel::{Receiver, TryRecvError};
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-use futuresdr::runtime::{Block, TypedBlock};
+use crossbeam_channel::Receiver;
+use futuresdr::prelude::*;
 
-/// Push samples from a channel into a flowgraph stream connection.
+/// Pull samples from a crossbeam channel into a stream in a flowgraph.
 ///
 /// # Outputs
 ///
-/// `out`: Samples pushed into the channel
+/// `out`: Samples pulled from the channel
 ///
 /// # Usage
 /// ```
 /// use crossbeam_channel;
 /// use fsdr_blocks::channel::CrossbeamSource;
-/// use futuresdr::blocks::{Head, VectorSink, VectorSinkBuilder};
-/// use futuresdr::log::debug;
-/// use futuresdr::runtime::{Flowgraph, Runtime};
+/// use futuresdr::prelude::*;
+/// use futuresdr::blocks::VectorSink;
 ///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut fg = Flowgraph::new();
-/// let orig = vec![0, 1, 2];
-/// let (tx, rx) = crossbeam_channel::unbounded::<Box<[u32]>>();
+/// let (tx, rx) = crossbeam_channel::unbounded::<Box<[f32]>>();
 ///
-/// let crossbeam_source = fg.add_block(CrossbeamSource::<u32>::new(rx));
-/// let limit = fg.add_block(Head::<u32>::new(orig.len() as u64));
-/// let vector_sink = fg.add_block(VectorSinkBuilder::<u32>::new().build());
+/// let orig: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+/// let src = CrossbeamSource::<f32>::new(rx.clone());
+/// let snk = VectorSink::<f32>::new(1024);
 ///
-/// fg.connect_stream(crossbeam_source, "out", limit, "in").unwrap();
-/// fg.connect_stream(limit, "out", vector_sink, "in").unwrap();
-/// tx.try_send(orig.clone().into_boxed_slice()).unwrap();
+/// tx.send(orig.clone().into()).unwrap();
+/// drop(tx);
 ///
-/// fg = Runtime::new().run(fg).unwrap();
+/// connect!(fg, src > snk);
+/// Runtime::new().run(fg)?;
 ///
-/// let snk = fg.kernel::<VectorSink<u32>>(vector_sink).unwrap();
-/// let received = snk.items();
-///
-/// debug!("{}", received.len());
-/// debug!("{}", orig.len());
-///
-/// assert_eq!(received.len(), orig.len());
-///
-/// for (v, e) in orig.iter().zip(received.iter()) {
-///     debug!("{v} == {e}");
-///     assert_eq!(v, e);
-/// }
+/// let snk_get = snk.get().unwrap();
+/// assert_eq!(orig, *snk_get.items());
+/// # Ok(())
+/// # }
 /// ```
-pub struct CrossbeamSource<T: Send + 'static> {
+#[derive(Block)]
+pub struct CrossbeamSource<
+    T: Send + Sync + Copy + 'static,
+    O: CpuBufferWriter<Item = T> = DefaultCpuWriter<T>,
+> {
+    #[output]
+    output: O,
     receiver: Receiver<Box<[T]>>,
     current: Option<(Box<[T]>, usize)>,
 }
 
-impl<T: Send + 'static> CrossbeamSource<T> {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(receiver: Receiver<Box<[T]>>) -> Block {
-        Block::from_typed(Self::new_typed(receiver))
-    }
-
-    pub fn new_typed(receiver: Receiver<Box<[T]>>) -> TypedBlock<Self> {
-        TypedBlock::new(
-            BlockMetaBuilder::new("CrossbeamSource").build(),
-            StreamIoBuilder::new().add_output::<T>("out").build(),
-            MessageIoBuilder::new().build(),
-            CrossbeamSource::<T> {
-                receiver,
-                current: None,
-            },
-        )
+impl<T: Send + Sync + Copy + 'static, O: CpuBufferWriter<Item = T>> CrossbeamSource<T, O> {
+    pub fn new(receiver: Receiver<Box<[T]>>) -> Self {
+        CrossbeamSource {
+            output: O::default(),
+            receiver,
+            current: None,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T: Send + 'static> Kernel for CrossbeamSource<T> {
+impl<T: Send + Sync + Copy + 'static, O: CpuBufferWriter<Item = T>> Kernel
+    for CrossbeamSource<T, O>
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let out = sio.output(0).slice::<T>();
-        if out.is_empty() {
-            return Ok(());
-        }
+        let (produced, call_again, finished) = {
+            let out = self.output.slice();
+            if out.is_empty() {
+                return Ok(());
+            }
 
-        if self.current.is_none() {
-            match self.receiver.try_recv() {
-                //.by_ref().next().await {
-                Ok(data) => {
-                    // debug!("received data chunk on channel");
-                    self.current = Some((data, 0));
-                }
-                Err(TryRecvError::Empty) => {
-                    //debug!("channel empty");
-                }
-                Err(TryRecvError::Disconnected) => {
-                    // debug!("sender-end of channel was closed");
-                    io.finished = true;
-                    return Ok(());
+            let mut finished = false;
+            if self.current.is_none() {
+                match self.receiver.try_recv() {
+                    Ok(data) => {
+                        self.current = Some((data, 0));
+                    }
+                    Err(crossbeam_channel::TryRecvError::Empty) => {}
+                    Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                        finished = true;
+                    }
                 }
             }
-        }
 
-        if let Some((data, index)) = &mut self.current {
-            let n = std::cmp::min(data.len() - *index, out.len());
-            unsafe {
-                std::ptr::copy_nonoverlapping(data.as_ptr().add(*index), out.as_mut_ptr(), n);
-            };
-            sio.output(0).produce(n);
-            *index += n;
-            if *index == data.len() {
-                self.current = None;
+            let mut produced = 0;
+            if let Some((data, index)) = &mut self.current {
+                let n = std::cmp::min(data.len() - *index, out.len());
+                out[..n].copy_from_slice(&data[*index..*index + n]);
+                produced = n;
+                *index += n;
+                if *index == data.len() {
+                    self.current = None;
+                }
             }
-        }
+            (produced, self.current.is_none(), finished)
+        };
 
-        if self.current.is_none() {
-            io.call_again = true;
+        if produced > 0 {
+            self.output.produce(produced);
+        }
+        io.call_again = call_again;
+        if finished {
+            io.finished = true;
         }
 
         Ok(())

--- a/src/cw/baseband_to_cw.rs
+++ b/src/cw/baseband_to_cw.rs
@@ -1,20 +1,18 @@
-use async_trait::async_trait;
 use std::ops::RangeInclusive;
 
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-use futuresdr::runtime::{Block, TypedBlock};
+use futuresdr::prelude::*;
 
 use crate::cw::shared::CWAlphabet::{self, *};
 
-pub struct BaseBandToCW {
+#[derive(Block)]
+pub struct BaseBandToCW<
+    I: CpuBufferReader<Item = f32> = DefaultCpuReader<f32>,
+    O: CpuBufferWriter<Item = CWAlphabet> = DefaultCpuWriter<CWAlphabet>,
+> {
+    #[input]
+    input: I,
+    #[output]
+    output: O,
     samples_per_dot: usize,
     sample_count: usize,
     power_before: f32,
@@ -28,18 +26,10 @@ pub struct BaseBandToCW {
 }
 
 impl BaseBandToCW {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         accuracy: usize, // 100 = 100% accuracy = How accurate the timeslots for symbols and between symbols have to be kept
         samples_per_dot: usize,
-    ) -> Block {
-        Block::from_typed(Self::new_typed(accuracy, samples_per_dot))
-    }
-
-    pub fn new_typed(
-        accuracy: usize, // 100 = 100% accuracy = How accurate the timeslots for symbols and between symbols have to be kept
-        samples_per_dot: usize,
-    ) -> TypedBlock<Self> {
+    ) -> Self {
         let tolerance_per_dot =
             (samples_per_dot as f32 - ((accuracy as f32 / 100.) * samples_per_dot as f32)) as usize;
         let dot_range = samples_per_dot - tolerance_per_dot..=samples_per_dot + tolerance_per_dot;
@@ -50,137 +40,150 @@ impl BaseBandToCW {
         let wordspace_range =
             7 * samples_per_dot - tolerance_per_dot..=7 * samples_per_dot + tolerance_per_dot;
 
-        println!("samples per dot: {}", samples_per_dot);
-        println!("dot_range: {:?}", dot_range);
-        println!("dash_range: {:?}", dash_range);
-        println!("letterspace_range: {:?}", letterspace_range);
-        println!("wordspace_range: {:?}", wordspace_range);
+        // println!("samples per dot: {}", samples_per_dot);
+        // println!("dot_range: {:?}", dot_range);
+        // println!("dash_range: {:?}", dash_range);
+        // println!("letterspace_range: {:?}", letterspace_range);
+        // println!("wordspace_range: {:?}", wordspace_range);
 
-        TypedBlock::new(
-            BlockMetaBuilder::new("BBToCW").build(),
-            StreamIoBuilder::new()
-                .add_input::<f32>("in")
-                .add_output::<CWAlphabet>("out")
-                .build(),
-            MessageIoBuilder::new().build(),
-            BaseBandToCW {
-                samples_per_dot,
-                sample_count: 0,
-                power_before: 0.,
-                tolerance_per_dot, // // Tolerance towards the sending end in sticking to the time slots
-                dot_range,         // How many samples are still interpreted as a dot
-                dash_range,
-                letterspace_range,
-                wordspace_range,
-            },
-        )
+        BaseBandToCW {
+            input: DefaultCpuReader::<f32>::default(),
+            output: DefaultCpuWriter::<CWAlphabet>::default(),
+            samples_per_dot,
+            sample_count: 0,
+            power_before: 0.,
+            tolerance_per_dot, // // Tolerance towards the sending end in sticking to the time slots
+            dot_range,         // How many samples are still interpreted as a dot
+            dash_range,
+            letterspace_range,
+            wordspace_range,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl Kernel for BaseBandToCW {
+impl<I, O> Kernel for BaseBandToCW<I, O>
+where
+    I: CpuBufferReader<Item = f32>,
+    O: CpuBufferWriter<Item = CWAlphabet>,
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<f32>();
-        let o = sio.output(0).slice::<CWAlphabet>();
-        if o.is_empty() {
-            return Ok(());
-        }
+        let (consumed, produced, finished) = {
+            let i = self.input.slice();
+            let o = self.output.slice();
+            if o.len() < 2 {
+                // We might produce 2 symbols at once (End of transmission)
+                return Ok(());
+            }
 
-        let mut consumed = 0;
-        let mut produced = 0;
-        let mut end_of_transmission = true;
-        let threshold = 0.5; //(self.avg_power_min + self.avg_power_max) / 2.;
+            let mut consumed = 0;
+            let mut produced = 0;
+            let mut end_of_transmission = true;
+            let threshold = 0.5; //(self.avg_power_min + self.avg_power_max) / 2.;
 
-        let mut symbol = None;
-        for sample in i.iter() {
-            let power = (*sample).abs(); //.powi(2); // Not required
+            let mut symbol = None;
+            let i_len = i.len();
+            for sample in i.iter() {
+                let power = (*sample).abs(); //.powi(2); // Not required
 
-            if (power > threshold) && (self.power_before <= threshold) {
-                // Signal is starting
-                match self.sample_count {
-                    x if self.wordspace_range.contains(&x) => {
-                        symbol = Some(WordSpace);
-                    } // Wordspace 7 dots (incl tolerance)
-                    x if self.letterspace_range.contains(&x) => {
-                        symbol = Some(LetterSpace);
-                    } // Letterspace (Longer than 3 dots (incl tolerance), but shorter than 7 dots (incl tolerance))
-                    x if self.dot_range.contains(&x) => {} // SymbolSpace (Is a valid symbol)
-                    _ => {
-                        //info!("Signal pause not a symbol: {} samples", self.sample_count);
+                if (power > threshold) && (self.power_before <= threshold) {
+                    // Signal is starting
+                    match self.sample_count {
+                        x if self.wordspace_range.contains(&x) => {
+                            symbol = Some(WordSpace);
+                        } // Wordspace 7 dots (incl tolerance)
+                        x if self.letterspace_range.contains(&x) => {
+                            symbol = Some(LetterSpace);
+                        } // Letterspace (Longer than 3 dots (incl tolerance), but shorter than 7 dots (incl tolerance))
+                        x if self.dot_range.contains(&x) => {} // SymbolSpace (Is a valid symbol)
+                        _ => {
+                            //info!("Signal pause not a symbol: {} samples", self.sample_count);
+                        }
                     }
+
+                    // println!(
+                    //     "Signal was paused for: {} -> {:?}",
+                    //     self.sample_count,
+                    //     symbol.or(None)
+                    // );
+
+                    self.sample_count = 0;
+                    end_of_transmission = false;
+                }
+                if (power <= threshold) && (self.power_before > threshold) {
+                    // Signal is stopping
+                    match self.sample_count {
+                        x if self.dot_range.contains(&x) => {
+                            symbol = Some(Dot);
+                        }
+                        x if self.dash_range.contains(&x) => {
+                            symbol = Some(Dash);
+                        }
+                        _ => {
+                            //info!("Signal length not a symbol: {} samples", self.sample_count);
+                        }
+                    }
+
+                    // println!(
+                    //     "Signal was present for: {} -> {:?}",
+                    //     self.sample_count,
+                    //     symbol.or(None)
+                    // );
+
+                    self.sample_count = 0;
                 }
 
-                println!(
-                    "Signal was paused for: {} -> {:?}",
-                    self.sample_count,
-                    symbol.or(None)
-                );
-
-                self.sample_count = 0;
-                end_of_transmission = false;
-            }
-            if (power <= threshold) && (self.power_before > threshold) {
-                // Signal is stopping
-                match self.sample_count {
-                    x if self.dot_range.contains(&x) => {
-                        symbol = Some(Dot);
-                    }
-                    x if self.dash_range.contains(&x) => {
-                        symbol = Some(Dash);
-                    }
-                    _ => {
-                        //info!("Signal length not a symbol: {} samples", self.sample_count);
-                    }
+                if let Some(val) = symbol {
+                    o[produced] = val;
+                    produced += 1;
+                    symbol = None;
                 }
 
-                println!(
-                    "Signal was present for: {} -> {:?}",
-                    self.sample_count,
-                    symbol.or(None)
-                );
+                // Special Case: No signal has been received for a longer time than a wordspace needs.
+                if self.sample_count > (self.tolerance_per_dot + (7 * self.samples_per_dot))
+                    && !end_of_transmission
+                {
+                    // End of transmission
+                    //println!("Transmission ended!");
+                    end_of_transmission = true;
+                    o[produced] = LetterSpace;
+                    o[produced + 1] = WordSpace;
+                    produced += 2;
+                }
 
-                self.sample_count = 0;
+                if self.sample_count == usize::MAX {
+                    // Dont overflow
+                    self.sample_count = 0;
+                }
+
+                self.sample_count += 1;
+                self.power_before = power;
+                consumed += 1;
+
+                if produced >= o.len() - 2 {
+                    break;
+                }
             }
+            (
+                consumed,
+                produced,
+                self.input.finished() && consumed == i_len,
+            )
+        };
 
-            if let Some(val) = symbol {
-                o[produced] = val;
-                produced += 1;
-                symbol = None;
-            }
-
-            // Special Case: No signal has been received for a longer time than a wordspace needs.
-            if self.sample_count > (self.tolerance_per_dot + (7 * self.samples_per_dot))
-                && !end_of_transmission
-            {
-                // End of transmission
-                //println!("Transmission ended!");
-                end_of_transmission = true;
-                o[produced] = LetterSpace;
-                o[produced + 1] = WordSpace;
-                produced += 2;
-            }
-
-            if self.sample_count == usize::MAX {
-                // Dont overflow
-                self.sample_count = 0;
-            }
-
-            self.sample_count += 1;
-            self.power_before = power;
-            consumed += 1;
+        if consumed > 0 {
+            self.input.consume(consumed);
+        }
+        if produced > 0 {
+            self.output.produce(produced);
         }
 
-        sio.input(0).consume(consumed);
-        sio.output(0).produce(produced);
-
-        if sio.input(0).finished() && consumed == i.len() {
+        if finished {
             io.finished = true;
         }
 
@@ -207,8 +210,8 @@ impl BaseBandToCWBuilder {
         BaseBandToCWBuilder::default()
     }
 
-    pub fn samples_per_dot(mut self, samles_per_dot: usize) -> BaseBandToCWBuilder {
-        self.samles_per_dot = samles_per_dot;
+    pub fn samples_per_dot(mut self, samples_per_dot: usize) -> BaseBandToCWBuilder {
+        self.samles_per_dot = samples_per_dot;
         self
     }
 
@@ -217,7 +220,7 @@ impl BaseBandToCWBuilder {
         self
     }
 
-    pub fn build(self) -> Block {
+    pub fn build(self) -> BaseBandToCW {
         BaseBandToCW::new(self.accuracy, self.samles_per_dot)
     }
 }

--- a/src/cw/cw_to_char.rs
+++ b/src/cw/cw_to_char.rs
@@ -1,95 +1,92 @@
-use async_trait::async_trait;
-
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-use futuresdr::runtime::{Block, TypedBlock};
+use futuresdr::prelude::*;
 
 use crate::cw::shared::get_alphabet;
 use crate::cw::shared::CWAlphabet::{self, LetterSpace, WordSpace};
 use bimap::BiMap;
 
-pub struct CWToChar {
+#[derive(Block)]
+pub struct CWToChar<
+    I: CpuBufferReader<Item = CWAlphabet> = DefaultCpuReader<CWAlphabet>,
+    O: CpuBufferWriter<Item = u32> = DefaultCpuWriter<u32>,
+> {
+    #[input]
+    input: I,
+    #[output]
+    output: O,
     // Required to keep the state of already received pulses
     symbol_vec: Vec<CWAlphabet>,
     alphabet: BiMap<char, Vec<CWAlphabet>>,
 }
 
 impl CWToChar {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(alphabet: BiMap<char, Vec<CWAlphabet>>) -> Block {
-        Block::from_typed(Self::new_typed(alphabet))
-    }
-
-    pub fn new_typed(alphabet: BiMap<char, Vec<CWAlphabet>>) -> TypedBlock<Self> {
-        TypedBlock::new(
-            BlockMetaBuilder::new("CWToChar").build(),
-            StreamIoBuilder::new()
-                .add_input::<CWAlphabet>("in")
-                .add_output::<char>("out")
-                .build(),
-            MessageIoBuilder::new().build(),
-            CWToChar {
-                symbol_vec: vec![],
-                alphabet,
-            },
-        )
+    pub fn new(alphabet: BiMap<char, Vec<CWAlphabet>>) -> Self {
+        CWToChar {
+            input: DefaultCpuReader::<CWAlphabet>::default(),
+            output: DefaultCpuWriter::<u32>::default(),
+            symbol_vec: vec![],
+            alphabet,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl Kernel for CWToChar {
+impl<I, O> Kernel for CWToChar<I, O>
+where
+    I: CpuBufferReader<Item = CWAlphabet>,
+    O: CpuBufferWriter<Item = u32>,
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        // Not doing any checks on the output buffer length here.
-        // Assuming, that i and o are of the same length.
-        // Assuming, that one input sample generates at max one output sample.
-        let i = sio.input(0).slice::<CWAlphabet>();
-        let o = sio.output(0).slice::<char>();
+        let i = self.input.slice();
+        let o = self.output.slice();
 
-        let mut produced = 0;
+        let (consumed, produced, finished) = if i.is_empty() {
+            (0, 0, self.input.finished())
+        } else {
+            // Not doing any checks on the output buffer length here.
+            // Assuming, that i and o are of the same length.
+            // Assuming, that one input sample generates at max one output sample.
+            self.symbol_vec.append(&mut i.to_vec());
 
-        self.symbol_vec.append(&mut i.to_vec());
+            let mut produced = 0;
+            if self.symbol_vec.contains(&WordSpace) || self.symbol_vec.contains(&LetterSpace) {
+                let symbols: Vec<_> = self
+                    .symbol_vec
+                    .split_inclusive(|c| c == &LetterSpace || c == &WordSpace)
+                    .filter_map(|c| c.split_last())
+                    .map(|(last, elements)| {
+                        //println!("last: {}, elements: {:?}", last, elements);
+                        if last == &WordSpace {
+                            *self.alphabet.get_by_right(&vec![WordSpace]).unwrap_or(&'_')
+                        } else {
+                            *self.alphabet.get_by_right(elements).unwrap_or(&'_')
+                        }
+                    })
+                    .collect();
 
-        if self.symbol_vec.contains(&WordSpace) || self.symbol_vec.contains(&LetterSpace) {
-            for (index, c) in self
-                .symbol_vec
-                .split_inclusive(|c| c == &LetterSpace || c == &WordSpace)
-                .filter_map(|c| c.split_last())
-                .map(|(last, elements)| {
-                    //println!("last: {}, elements: {:?}", last, elements);
-                    if last == &WordSpace {
-                        *self.alphabet.get_by_right(&vec![WordSpace]).unwrap_or(&'_')
-                    } else {
-                        *self.alphabet.get_by_right(elements).unwrap_or(&'_')
-                    }
-                })
-                .enumerate()
-            {
-                o[index] = c;
-                produced = index + 1;
-                //println!("c: {}, index: {}, produced: {}", c, index, produced);
+                let n = std::cmp::min(symbols.len(), o.len());
+                for j in 0..n {
+                    o[j] = symbols[j] as u32;
+                    //println!("c: {}, index: {}, produced: {}", c, index, produced);
+                }
+                produced = n;
+                self.symbol_vec.clear(); // This might be wrong if we didn't consume everything, but original did this
             }
 
-            self.symbol_vec.clear();
+            (i.len(), produced, self.input.finished())
+        };
+
+        if consumed > 0 {
+            self.input.consume(consumed);
         }
-
-        sio.input(0).consume(i.len());
-        sio.output(0).produce(produced);
-
-        if sio.input(0).finished() {
+        if produced > 0 {
+            self.output.produce(produced);
+        }
+        if finished {
             io.finished = true;
         }
 
@@ -119,7 +116,7 @@ impl CWToCharBuilder {
         self
     }*/
 
-    pub fn build(self) -> Block {
+    pub fn build(self) -> CWToChar {
         CWToChar::new(self.alphabet)
     }
 }

--- a/src/cw/shared.rs
+++ b/src/cw/shared.rs
@@ -1,12 +1,13 @@
 use bimap::BiMap;
 use std::fmt;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
 pub enum CWAlphabet {
     Dot,
     Dash,
     LetterSpace,
     WordSpace,
+    #[default]
     Unknown,
 }
 
@@ -139,7 +140,7 @@ pub fn char_to_baseband(samles_per_dot: usize) -> impl FnMut(&char) -> Vec<f32> 
 ///
 /// # Usage
 /// ```
-/// use futuresdr::log::debug;
+///
 /// use fsdr_blocks::cw::shared::msg_to_cw;
 /// use fsdr_blocks::cw::shared::CWAlphabet::*;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 
 // #![feature(async_fn_in_trait)]
 
-#[macro_use]
-pub extern crate async_trait;
-
 #[cfg(feature = "crossbeam")]
 pub mod channel;
 

--- a/src/math/freq_shift.rs
+++ b/src/math/freq_shift.rs
@@ -1,3 +1,4 @@
+use futuresdr::blocks::signal_source::FixedPointPhase;
 use futuresdr::blocks::signal_source::NCO;
 use futuresdr::num_complex::Complex32;
 use futuresdr::prelude::*;
@@ -25,6 +26,7 @@ pub struct FrequencyShifter<
     #[output]
     output: O,
     nco: NCO,
+    phase_inc: FixedPointPhase,
 }
 
 impl<A, I, O> FrequencyShifter<A, I, O>
@@ -35,14 +37,13 @@ where
 {
     /// Create FrequencyShifter block
     pub fn new(frequency: f32, sample_rate: f32) -> Self {
-        let nco = NCO::new(
-            0.0f32,
-            2.0 * core::f32::consts::PI * frequency / sample_rate,
-        );
+        let phase_inc = 2.0 * core::f32::consts::PI * frequency / sample_rate;
+        let nco = NCO::new(0.0f32, phase_inc);
         Self {
             input: I::default(),
             output: O::default(),
             nco,
+            phase_inc: FixedPointPhase::new(phase_inc),
         }
     }
 }
@@ -104,7 +105,7 @@ where
 
             let m = std::cmp::min(i.len(), o.len());
             if m > 0 {
-                let rotation = Complex32::new(self.nco.phase_inc.cos(), self.nco.phase_inc.sin());
+                let rotation = Complex32::new(self.phase_inc.cos(), self.phase_inc.sin());
                 let mut current_phasor = Complex32::new(self.nco.phase.cos(), self.nco.phase.sin());
                 for (v, r) in i[..m].iter().zip(o[..m].iter_mut()) {
                     *r = (*v) * current_phasor;

--- a/src/math/freq_shift.rs
+++ b/src/math/freq_shift.rs
@@ -1,15 +1,6 @@
 use futuresdr::blocks::signal_source::NCO;
 use futuresdr::num_complex::Complex32;
-use futuresdr::runtime::Block;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
+use futuresdr::prelude::*;
 
 /// This blocks shift the signal in the frequency domain based on the [`NCO`] implementation.
 /// Currently implemented only for float and [`Complex32`]
@@ -23,65 +14,71 @@ use futuresdr::runtime::WorkIo;
 /// # let sample_rate = 48_000;
 /// let blk = FrequencyShifter::<Complex32>::new(freq as f32, sample_rate as f32);
 /// ```
-pub struct FrequencyShifter<A>
-where
-    A: Send + 'static + Copy,
-{
-    _p1: std::marker::PhantomData<A>,
+#[derive(Block)]
+pub struct FrequencyShifter<
+    A: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
+    I: CpuBufferReader<Item = A> = DefaultCpuReader<A>,
+    O: CpuBufferWriter<Item = A> = DefaultCpuWriter<A>,
+> {
+    #[input]
+    input: I,
+    #[output]
+    output: O,
     nco: NCO,
 }
 
-impl<A> FrequencyShifter<A>
+impl<A, I, O> FrequencyShifter<A, I, O>
 where
-    A: Send + 'static + Copy,
-    FrequencyShifter<A>: futuresdr::runtime::Kernel,
+    A: Send + Sync + Default + Clone + std::fmt::Debug + 'static + Copy,
+    I: CpuBufferReader<Item = A>,
+    O: CpuBufferWriter<Item = A>,
 {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(frequency: f32, sample_rate: f32) -> Block {
+    /// Create FrequencyShifter block
+    pub fn new(frequency: f32, sample_rate: f32) -> Self {
         let nco = NCO::new(
             0.0f32,
             2.0 * core::f32::consts::PI * frequency / sample_rate,
         );
-        Block::new(
-            BlockMetaBuilder::new("FrequencyShift").build(),
-            StreamIoBuilder::new()
-                .add_input::<A>("in")
-                .add_output::<A>("out")
-                .build(),
-            MessageIoBuilder::<Self>::new().build(),
-            FrequencyShifter {
-                _p1: std::marker::PhantomData,
-                nco,
-            },
-        )
+        Self {
+            input: I::default(),
+            output: O::default(),
+            nco,
+        }
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl Kernel for FrequencyShifter<f32> {
+impl<I, O> Kernel for FrequencyShifter<f32, I, O>
+where
+    I: CpuBufferReader<Item = f32>,
+    O: CpuBufferWriter<Item = f32>,
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<f32>();
-        let o = sio.output(0).slice::<f32>();
+        let m = {
+            let i = self.input.slice();
+            let o = self.output.slice();
 
-        let m = std::cmp::min(i.len(), o.len());
-        if m > 0 {
-            for (v, r) in i.iter().zip(o.iter_mut()) {
-                *r = (*v) * self.nco.phase.cos();
-                self.nco.step();
+            let m = std::cmp::min(i.len(), o.len());
+            if m > 0 {
+                for (v, r) in i[..m].iter().zip(o[..m].iter_mut()) {
+                    *r = (*v) * self.nco.phase.cos();
+                    self.nco.step();
+                }
             }
+            m
+        };
 
-            sio.input(0).consume(m);
-            sio.output(0).produce(m);
+        if m > 0 {
+            self.input.consume(m);
+            self.output.produce(m);
         }
 
-        if sio.input(0).finished() && m == i.len() {
+        if self.input.finished() && self.input.slice().is_empty() {
             io.finished = true;
         }
 
@@ -90,30 +87,40 @@ impl Kernel for FrequencyShifter<f32> {
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl Kernel for FrequencyShifter<Complex32> {
+impl<I, O> Kernel for FrequencyShifter<Complex32, I, O>
+where
+    I: CpuBufferReader<Item = Complex32>,
+    O: CpuBufferWriter<Item = Complex32>,
+{
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice::<Complex32>();
-        let o = sio.output(0).slice::<Complex32>();
+        let m = {
+            let i = self.input.slice();
+            let o = self.output.slice();
 
-        let m = std::cmp::min(i.len(), o.len());
-        if m > 0 {
-            for (v, r) in i.iter().zip(o.iter_mut()) {
-                *r = (*v) * Complex32::new(self.nco.phase.cos(), self.nco.phase.sin());
-                self.nco.step();
+            let m = std::cmp::min(i.len(), o.len());
+            if m > 0 {
+                let rotation = Complex32::new(self.nco.phase_inc.cos(), self.nco.phase_inc.sin());
+                let mut current_phasor = Complex32::new(self.nco.phase.cos(), self.nco.phase.sin());
+                for (v, r) in i[..m].iter().zip(o[..m].iter_mut()) {
+                    *r = (*v) * current_phasor;
+                    current_phasor *= rotation;
+                }
+                self.nco.steps(m as i32);
             }
+            m
+        };
 
-            sio.input(0).consume(m);
-            sio.output(0).produce(m);
+        if m > 0 {
+            self.input.consume(m);
+            self.output.produce(m);
         }
 
-        if sio.input(0).finished() && m == i.len() {
+        if self.input.finished() && self.input.slice().is_empty() {
             io.finished = true;
         }
 

--- a/src/serde_pmt/deserialiser.rs
+++ b/src/serde_pmt/deserialiser.rs
@@ -25,7 +25,7 @@ impl PmtDist {
     }
 
     #[cold]
-    fn unexpected(&self) -> Unexpected {
+    fn unexpected(&self) -> Unexpected<'_> {
         match &self.0 {
             Pmt::Null => Unexpected::Unit,
             Pmt::Bool(b) => Unexpected::Bool(*b),

--- a/src/sigmf/sigmf_sink.rs
+++ b/src/sigmf/sigmf_sink.rs
@@ -2,16 +2,7 @@ use std::ffi::OsStr;
 use std::io::Write;
 use std::path::PathBuf;
 
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-use futuresdr::runtime::{Block, Pmt, Tag};
+use futuresdr::prelude::*;
 
 use sigmf::Annotation;
 use sigmf::{DatasetFormat, DescriptionBuilder};
@@ -39,46 +30,37 @@ use crate::serde_pmt::from_pmt;
 /// let sink = builder.build::<u16>();
 /// ```
 #[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
-pub struct SigMFSink<T, W, M>
-where
-    T: Send + 'static + Sized,
-    W: Write,
-    M: Write,
-{
+#[derive(Block)]
+pub struct SigMFSink<
+    T: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
+    W: Write + Send + 'static,
+    M: Write + Send + 'static,
+    I: CpuBufferReader<Item = T> = DefaultCpuReader<T>,
+> {
+    #[input]
+    input: I,
     pub writer: W,
     pub meta_writer: M,
     pub description: DescriptionBuilder,
     // global_index: usize,
     // sample_index: usize,
-    _sample_type: std::marker::PhantomData<T>,
-    _writer_type: std::marker::PhantomData<W>,
-    _meta_writer_type: std::marker::PhantomData<M>,
 }
 
-impl<T, W, M> SigMFSink<T, W, M>
+impl<T, W, M, I> SigMFSink<T, W, M, I>
 where
-    T: Send + 'static + Sized + std::marker::Sync,
-    W: Write + std::marker::Send + 'static, // + std::marker::Sync + std::marker::Send + std::marker::Unpin,
-    M: Write + std::marker::Send + 'static, //std::io::Write, // + Send + std::marker::Sync,
+    T: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
+    W: Write + Send + 'static,
+    M: Write + Send + 'static,
+    I: CpuBufferReader<Item = T>,
 {
     /// Create FileSink block
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(writer: W, description: DescriptionBuilder, meta_writer: M) -> Block {
-        Block::new(
-            BlockMetaBuilder::new("SigMFSink").build(),
-            StreamIoBuilder::new().add_input::<T>("in").build(),
-            MessageIoBuilder::new().build(),
-            SigMFSink::<T, W, M> {
-                writer,
-                meta_writer,
-                description,
-                // global_index: 0,
-                // sample_index: 0,
-                _sample_type: std::marker::PhantomData,
-                _writer_type: std::marker::PhantomData,
-                _meta_writer_type: std::marker::PhantomData,
-            },
-        )
+    pub fn new(writer: W, description: DescriptionBuilder, meta_writer: M) -> Self {
+        SigMFSink {
+            input: I::default(),
+            writer,
+            meta_writer,
+            description,
+        }
     }
 }
 
@@ -124,67 +106,63 @@ pub fn convert_pmt_to_annotation(value: &Pmt) -> Option<Annotation> {
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T, W, M> Kernel for SigMFSink<T, W, M>
+impl<T, W, M, I> Kernel for SigMFSink<T, W, M, I>
 where
-    T: Send + 'static + Sized + std::marker::Sync,
+    T: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
     W: Write + Send + 'static,
-    M: Write + Send, //std::io::Write + Send + std::marker::Sync,
+    M: Write + Send + 'static,
+    I: CpuBufferReader<Item = T>,
 {
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i = sio.input(0).slice_unchecked::<u8>();
+        let items = {
+            let (i, tags) = self.input.slice_with_tags();
+            let items = i.len();
 
-        let item_size = std::mem::size_of::<T>();
-        let items = i.len() / item_size;
-
-        if items > 0 {
-            let i = &i[..items * item_size];
-            let _ = self.writer.write_all(i)?;
-        }
-        for item in sio.input(0).tags() {
-            // let index = item.index;
-            #[allow(clippy::single_match)] // Because of todo!()
-            match &item.tag {
-                Tag::Data(pmt) => {
+            if items > 0 {
+                let bytes = unsafe {
+                    std::slice::from_raw_parts(i.as_ptr() as *const u8, std::mem::size_of_val(i))
+                };
+                self.writer.write_all(bytes)?;
+            }
+            for item in tags {
+                // let index = item.index;
+                #[allow(clippy::single_match)] // Because of todo!()
+                if let Tag::Data(pmt) = &item.tag {
                     if let Some(annot) = convert_pmt_to_annotation(pmt) {
                         self.description.add_annotation(annot)?;
                     }
-                }
-                _ => {
-                    todo!("Automate other pmt to annotation")
+                } else {
+                    // todo!("Automate other pmt to annotation")
                 }
             }
-        }
 
-        if sio.input(0).finished() {
-            io.finished = true;
-        }
+            if self.input.finished() {
+                io.finished = true;
+            }
+            items
+        };
 
-        sio.input(0).consume(items);
+        if items > 0 {
+            self.input.consume(items);
+        }
         Ok(())
     }
 
     // async fn init(
     //     &mut self,
     //     _sio: &mut StreamIo,
-    //     _mio: &mut MessageIo<Self>,
+    //     _mio: &mut MessageOutputs,
     //     _meta: &mut BlockMeta,
     // ) -> Result<()> {
     //     Ok(())
     // }
 
-    async fn deinit(
-        &mut self,
-        _sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
-        _meta: &mut BlockMeta,
-    ) -> Result<()> {
+    async fn deinit(&mut self, _mio: &mut MessageOutputs, _meta: &mut BlockMeta) -> Result<()> {
         let desc = self.description.build()?;
         desc.to_writer_pretty(&mut self.meta_writer)?;
         Ok(())
@@ -251,7 +229,9 @@ impl From<&str> for SigMFSinkBuilder {
 }
 
 impl SigMFSinkBuilder {
-    pub async fn build<T: Sized + 'static + Sync + Send>(&mut self) -> Result<Block> {
+    pub async fn build<T: Send + Sync + Default + Clone + std::fmt::Debug + 'static>(
+        &mut self,
+    ) -> Result<SigMFSink<T, std::fs::File, std::fs::File>> {
         let desc = DescriptionBuilder::from(self.datatype);
         self.basename.set_extension("sigmf-data");
         let actual_file = std::fs::File::create(&self.basename)?;

--- a/src/sigmf/sigmf_source.rs
+++ b/src/sigmf/sigmf_source.rs
@@ -3,23 +3,13 @@ use std::path::PathBuf;
 
 use futuresdr::futures::AsyncRead;
 use futuresdr::futures::AsyncReadExt;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
-use futuresdr::runtime::{Block, Tag};
+use futuresdr::prelude::*;
 
 use sigmf::RecordingBuilder;
 use sigmf::{Annotation, Description};
 
-use crate::serde_pmt;
-
 use super::BytesConveter;
+use crate::serde_pmt;
 
 /// Read samples from a SigMF file.
 ///
@@ -44,113 +34,112 @@ use super::BytesConveter;
 /// let source = builder.build::<u16>();
 /// ```
 #[cfg_attr(docsrs, doc(cfg(not(target_arch = "wasm32"))))]
-pub struct SigMFSource<T, R, F>
-where
-    T: Send + 'static + Sized,
-    R: AsyncRead,
+#[derive(Block)]
+pub struct SigMFSource<
+    T: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
+    R: AsyncRead + Send + Sync + Unpin + 'static,
     F: FnMut(&[u8]) -> T + Send + 'static,
-{
+    O: CpuBufferWriter<Item = T> = DefaultCpuWriter<T>,
+> {
+    #[output]
+    output: O,
     reader: R,
     annotations: Vec<Annotation>,
     // captures: Vec<Capture>,
     // global_index: usize,
     sample_index: usize,
-    _sample_type: std::marker::PhantomData<T>,
-    _reader_type: std::marker::PhantomData<R>,
     converter: F,
     item_size: usize,
 }
 
-impl<T, R, F> SigMFSource<T, R, F>
+impl<T, R, F, O> SigMFSource<T, R, F, O>
 where
-    T: Send + 'static + Sized + std::marker::Sync,
-    R: AsyncRead + std::marker::Sync + std::marker::Send + std::marker::Unpin + 'static,
+    T: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
+    R: AsyncRead + Send + Sync + Unpin + 'static,
     F: FnMut(&[u8]) -> T + Send + 'static,
+    O: CpuBufferWriter<Item = T>,
 {
     /// Create FileSource block
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(reader: R, desc: Description, converter: F) -> Result<Block> {
+    pub fn new(reader: R, desc: Description, converter: F) -> Result<Self> {
         let global = desc.global()?;
         let datatype = *global.datatype()?;
         let annotations = desc.annotations.unwrap_or_default();
         // let captures = desc.captures.unwrap_or_default();
-        Ok(Block::new(
-            BlockMetaBuilder::new("SigMFFileSource").build(),
-            StreamIoBuilder::new().add_output::<T>("out").build(),
-            MessageIoBuilder::new().build(),
-            SigMFSource::<T, R, F> {
-                reader,
-                annotations,
-                // captures,
-                // global_index: 0,
-                sample_index: 0,
-                _sample_type: std::marker::PhantomData,
-                _reader_type: std::marker::PhantomData,
-                converter,
-                item_size: datatype.size(),
-            },
-        ))
+        Ok(SigMFSource {
+            output: O::default(),
+            reader,
+            annotations,
+            sample_index: 0,
+            converter,
+            item_size: datatype.size(),
+        })
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<T, R, F> Kernel for SigMFSource<T, R, F>
+impl<T, R, F, O> Kernel for SigMFSource<T, R, F, O>
 where
-    T: Send + 'static + Sized + std::marker::Sync,
-    R: AsyncRead + std::marker::Send + std::marker::Sync + std::marker::Unpin,
+    T: Send + Sync + Default + Clone + std::fmt::Debug + 'static,
+    R: AsyncRead + Send + Sync + Unpin + 'static,
     F: FnMut(&[u8]) -> T + Send + 'static,
+    O: CpuBufferWriter<Item = T>,
 {
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let o = sio.output(0).slice::<T>();
+        let n_read_items = {
+            let o = self.output.slice();
 
-        let mut out = [0u8; 2048];
-        let mut i = 0;
-        // let max_produce = o.len();
-        // while i < max_produce {
-        match self.reader.read(&mut out[i..]).await {
-            Ok(0) => {
-                io.finished = true;
-                // break;
-            }
-            Ok(written) => {
-                for (v, r) in out.chunks_exact(self.item_size).zip(o) {
-                    *r = (self.converter)(v);
+            let mut buf = vec![0u8; o.len() * self.item_size];
+            let mut n_read_items = 0;
+            // let max_produce = o.len();
+            // while i < max_produce {
+            match self.reader.read(&mut buf).await {
+                Ok(0) => {
+                    io.finished = true;
+                    // break;
                 }
-                i += written / self.item_size;
+                Ok(n_read_bytes) => {
+                    n_read_items = n_read_bytes / self.item_size;
+                    for (v, r) in buf.chunks_exact(self.item_size).zip(o.iter_mut()) {
+                        *r = (self.converter)(v);
+                    }
+                }
+                Err(e) => panic!("SigMFSource: Error reading data: {e:?}"),
             }
-            Err(e) => panic!("SigMFSource: Error reading data: {e:?}"),
-        }
-        // }
+            // }
 
-        while let Some(annot) = self.annotations.first() {
-            if let Some(annot_sample_start) = annot.sample_start {
-                let upper_sample_index = self.sample_index + i;
-                if (self.sample_index..upper_sample_index).contains(&annot_sample_start) {
-                    let tag = serde_pmt::to_pmt(annot)?;
-                    let tag = Tag::Data(tag);
-                    sio.output(0)
-                        .add_tag(annot_sample_start - self.sample_index, tag);
+            while let Some(annot) = self.annotations.first() {
+                if let Some(annot_sample_start) = annot.sample_start {
+                    let upper_sample_index = self.sample_index + n_read_items;
+                    if (self.sample_index..upper_sample_index).contains(&annot_sample_start) {
+                        let tag = serde_pmt::to_pmt(annot)?;
+                        let tag = Tag::Data(tag);
+                        self.output
+                            .slice_with_tags()
+                            .1
+                            .add_tag(annot_sample_start - self.sample_index, tag);
 
-                    self.annotations.remove(0);
+                        self.annotations.remove(0);
+                    } else {
+                        break;
+                    }
                 } else {
-                    break;
+                    // Skip all annotations without sample_start
+                    self.annotations.remove(0);
                 }
-            } else {
-                // Skip all annotations without sample_start
-                self.annotations.remove(0);
             }
-        }
+            n_read_items
+        };
 
-        // println!("written: {:?}", i);
-        sio.output(0).produce(i);
-        self.sample_index += i;
+        // println!("written: {:?}", n_read_items);
+        if n_read_items > 0 {
+            self.output.produce(n_read_items);
+            self.sample_index += n_read_items;
+        }
 
         Ok(())
     }
@@ -222,7 +211,9 @@ impl SigMFSourceBuilder {
         SigMFSourceBuilderFromReader { data: reader, desc }
     }
 
-    pub async fn build<T: Sized + 'static + Send + Sync>(&mut self) -> Result<Block>
+    pub async fn build<T: Send + Sync + Default + Clone + std::fmt::Debug + 'static>(
+        &mut self,
+    ) -> Result<SigMFSource<T, async_fs::File, impl FnMut(&[u8]) -> T + Send + 'static>>
     where
         sigmf::DatasetFormat: BytesConveter<T>,
     {
@@ -237,9 +228,11 @@ impl SigMFSourceBuilder {
 
 impl<R> SigMFSourceBuilderFromReader<R>
 where
-    R: AsyncRead + std::marker::Send + std::marker::Sync + std::marker::Unpin + 'static,
+    R: AsyncRead + Send + Sync + Unpin + 'static,
 {
-    pub async fn build<T: Sized + 'static + Send + Sync>(self) -> Result<Block>
+    pub async fn build<T: Send + Sync + Default + Clone + std::fmt::Debug + 'static>(
+        self,
+    ) -> Result<SigMFSource<T, R, impl FnMut(&[u8]) -> T + Send + 'static>>
     where
         sigmf::DatasetFormat: BytesConveter<T>,
     {

--- a/src/stdinout.rs
+++ b/src/stdinout.rs
@@ -3,14 +3,15 @@
 use core::marker::PhantomData;
 use futuresdr::blocks::Sink;
 use futuresdr::num_complex::Complex32;
-use futuresdr::runtime::Block;
 use std::io::Write;
 
+#[derive(Clone, Copy)]
 enum StdDirection {
     In,
     Out,
 }
 
+#[derive(Clone, Copy)]
 enum BytesOrder {
     Native,
     BigEndian,
@@ -79,17 +80,14 @@ impl<A> StdInOutBuilder<A> {
 }
 
 impl StdInOutBuilder<u8> {
-    pub fn build(self) -> Block {
+    pub fn build(self) -> Sink<impl FnMut(&u8) + Send + 'static, u8> {
         match self.direction {
             StdDirection::Out => {
                 let mut stdout = std::io::stdout();
-                Sink::new(move |f: &i16| {
-                    stdout
-                        .write_all(&f.to_ne_bytes())
-                        .expect("cannot write to stdout");
+                Sink::new(move |f: &u8| {
+                    stdout.write_all(&[*f]).expect("cannot write to stdout");
                     stdout.flush().expect("flush error on stdout");
                 })
-                .into()
             }
             _ => todo!("stdin not yet implemented"),
         }
@@ -97,33 +95,25 @@ impl StdInOutBuilder<u8> {
 }
 
 impl StdInOutBuilder<i16> {
-    pub fn build(self) -> Block {
+    pub fn build(self) -> Sink<impl FnMut(&i16) + Send + 'static, i16> {
         match self.direction {
             StdDirection::Out => {
                 let mut stdout = std::io::stdout();
-                match self.bytes_order {
-                    BytesOrder::Native => Sink::new(move |f: &i16| {
-                        stdout
+                let bytes_order = self.bytes_order;
+                Sink::new(move |f: &i16| {
+                    match bytes_order {
+                        BytesOrder::Native => stdout
                             .write_all(&f.to_ne_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                    BytesOrder::LittleEndian => Sink::new(move |f: &i16| {
-                        stdout
+                            .expect("cannot write to stdout"),
+                        BytesOrder::LittleEndian => stdout
                             .write_all(&f.to_le_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                    BytesOrder::BigEndian => Sink::new(move |f: &i16| {
-                        stdout
+                            .expect("cannot write to stdout"),
+                        BytesOrder::BigEndian => stdout
                             .write_all(&f.to_be_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                }
+                            .expect("cannot write to stdout"),
+                    }
+                    stdout.flush().expect("flush error on stdout");
+                })
             }
             _ => todo!("stdin not yet implemented"),
         }
@@ -131,33 +121,25 @@ impl StdInOutBuilder<i16> {
 }
 
 impl StdInOutBuilder<f32> {
-    pub fn build(self) -> Block {
+    pub fn build(self) -> Sink<impl FnMut(&f32) + Send + 'static, f32> {
         match self.direction {
             StdDirection::Out => {
                 let mut stdout = std::io::stdout();
-                match self.bytes_order {
-                    BytesOrder::Native => Sink::new(move |f: &f32| {
-                        stdout
+                let bytes_order = self.bytes_order;
+                Sink::new(move |f: &f32| {
+                    match bytes_order {
+                        BytesOrder::Native => stdout
                             .write_all(&f.to_ne_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                    BytesOrder::LittleEndian => Sink::new(move |f: &f32| {
-                        stdout
+                            .expect("cannot write to stdout"),
+                        BytesOrder::LittleEndian => stdout
                             .write_all(&f.to_le_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                    BytesOrder::BigEndian => Sink::new(move |f: &f32| {
-                        stdout
+                            .expect("cannot write to stdout"),
+                        BytesOrder::BigEndian => stdout
                             .write_all(&f.to_be_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                }
+                            .expect("cannot write to stdout"),
+                    }
+                    stdout.flush().expect("flush error on stdout");
+                })
             }
             _ => todo!("stdin not yet implemented"),
         }
@@ -165,42 +147,40 @@ impl StdInOutBuilder<f32> {
 }
 
 impl StdInOutBuilder<Complex32> {
-    pub fn build(self) -> Block {
+    pub fn build(self) -> Sink<impl FnMut(&Complex32) + Send + 'static, Complex32> {
         match self.direction {
             StdDirection::Out => {
                 let mut stdout = std::io::stdout();
-                match self.bytes_order {
-                    BytesOrder::Native => Sink::new(move |f: &Complex32| {
-                        stdout
-                            .write_all(&f.re.to_ne_bytes())
-                            .expect("cannot write to stdout");
-                        stdout
-                            .write_all(&f.im.to_ne_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                    BytesOrder::LittleEndian => Sink::new(move |f: &Complex32| {
-                        stdout
-                            .write_all(&f.re.to_le_bytes())
-                            .expect("cannot write to stdout");
-                        stdout
-                            .write_all(&f.im.to_le_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                    BytesOrder::BigEndian => Sink::new(move |f: &Complex32| {
-                        stdout
-                            .write_all(&f.re.to_be_bytes())
-                            .expect("cannot write to stdout");
-                        stdout
-                            .write_all(&f.im.to_be_bytes())
-                            .expect("cannot write to stdout");
-                        stdout.flush().expect("flush error on stdout");
-                    })
-                    .into(),
-                }
+                let bytes_order = self.bytes_order;
+                Sink::new(move |f: &Complex32| {
+                    match bytes_order {
+                        BytesOrder::Native => {
+                            stdout
+                                .write_all(&f.re.to_ne_bytes())
+                                .expect("cannot write to stdout");
+                            stdout
+                                .write_all(&f.im.to_ne_bytes())
+                                .expect("cannot write to stdout");
+                        }
+                        BytesOrder::LittleEndian => {
+                            stdout
+                                .write_all(&f.re.to_le_bytes())
+                                .expect("cannot write to stdout");
+                            stdout
+                                .write_all(&f.im.to_le_bytes())
+                                .expect("cannot write to stdout");
+                        }
+                        BytesOrder::BigEndian => {
+                            stdout
+                                .write_all(&f.re.to_be_bytes())
+                                .expect("cannot write to stdout");
+                            stdout
+                                .write_all(&f.im.to_be_bytes())
+                                .expect("cannot write to stdout");
+                        }
+                    }
+                    stdout.flush().expect("flush error on stdout");
+                })
             }
             _ => todo!("stdin not yet implemented"),
         }

--- a/src/stream/deinterleave.rs
+++ b/src/stream/deinterleave.rs
@@ -1,13 +1,4 @@
-use futuresdr::runtime::Block;
-use futuresdr::runtime::BlockMeta;
-use futuresdr::runtime::BlockMetaBuilder;
-use futuresdr::runtime::Kernel;
-use futuresdr::runtime::MessageIo;
-use futuresdr::runtime::MessageIoBuilder;
-use futuresdr::runtime::Result;
-use futuresdr::runtime::StreamIo;
-use futuresdr::runtime::StreamIoBuilder;
-use futuresdr::runtime::WorkIo;
+use futuresdr::prelude::*;
 
 /// This blocks deinterleave a unique stream into two separate stream.
 /// Typically used to deinterleave iq stream into of stream for `i` and one for `q`.
@@ -17,85 +8,102 @@ use futuresdr::runtime::WorkIo;
 /// use fsdr_blocks::stream::Deinterleave;
 /// let blk = Deinterleave::<f32>::new();
 /// ```
-pub struct Deinterleave<A>
-where
-    A: Send + 'static + Copy,
-{
-    _p1: std::marker::PhantomData<A>,
+#[derive(Block)]
+pub struct Deinterleave<
+    A: Send + Sync + Default + Clone + std::fmt::Debug + 'static + Copy,
+    I: CpuBufferReader<Item = A> = DefaultCpuReader<A>,
+    O0: CpuBufferWriter<Item = A> = DefaultCpuWriter<A>,
+    O1: CpuBufferWriter<Item = A> = DefaultCpuWriter<A>,
+> {
+    #[input]
+    input: I,
+    #[output]
+    out0: O0,
+    #[output]
+    out1: O1,
     first: bool,
 }
 
-impl<A> Deinterleave<A>
+impl<A, I, O0, O1> Deinterleave<A, I, O0, O1>
 where
-    A: Send + 'static + Copy,
+    A: Send + Sync + Default + Clone + std::fmt::Debug + 'static + Copy,
+    I: CpuBufferReader<Item = A>,
+    O0: CpuBufferWriter<Item = A>,
+    O1: CpuBufferWriter<Item = A>,
 {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> Block {
-        Block::new(
-            BlockMetaBuilder::new("Deinterleave").build(),
-            StreamIoBuilder::new()
-                .add_input::<A>("in")
-                .add_output::<A>("out0")
-                .add_output::<A>("out1")
-                .build(),
-            MessageIoBuilder::<Self>::new().build(),
-            Deinterleave {
-                _p1: std::marker::PhantomData,
-                first: true,
-            },
-        )
+    pub fn new() -> Self {
+        Self {
+            input: I::default(),
+            out0: O0::default(),
+            out1: O1::default(),
+            first: true,
+        }
+    }
+}
+
+impl<A, I, O0, O1> Default for Deinterleave<A, I, O0, O1>
+where
+    A: Send + Sync + Default + Clone + std::fmt::Debug + 'static + Copy,
+    I: CpuBufferReader<Item = A>,
+    O0: CpuBufferWriter<Item = A>,
+    O1: CpuBufferWriter<Item = A>,
+{
+    fn default() -> Self {
+        Self::new()
     }
 }
 
 #[doc(hidden)]
-#[async_trait]
-impl<A> Kernel for Deinterleave<A>
+impl<A, I, O0, O1> Kernel for Deinterleave<A, I, O0, O1>
 where
-    A: Send + 'static + Copy,
+    A: Send + Sync + Default + Clone + std::fmt::Debug + 'static + Copy,
+    I: CpuBufferReader<Item = A>,
+    O0: CpuBufferWriter<Item = A>,
+    O1: CpuBufferWriter<Item = A>,
 {
     async fn work(
         &mut self,
         io: &mut WorkIo,
-        sio: &mut StreamIo,
-        _mio: &mut MessageIo<Self>,
+        _mio: &mut MessageOutputs,
         _meta: &mut BlockMeta,
     ) -> Result<()> {
-        let i0 = sio.input(0).slice::<A>();
-        let mut m0 = 0;
-        let mut m1 = 0;
-        let o0 = sio.output(0).slice::<A>();
-        let o1 = sio.output(1).slice::<A>();
+        let (m, m0, m1) = {
+            let i0 = self.input.slice();
+            let o0 = self.out0.slice();
+            let o1 = self.out1.slice();
 
-        let mut it0 = o0.iter_mut();
-        let mut it1 = o1.iter_mut();
+            let mut m0 = 0;
+            let mut m1 = 0;
 
-        for x in i0.iter() {
-            if self.first {
-                let d = it0.next();
-                if d.is_none() {
-                    break;
+            let mut it0 = o0.iter_mut();
+            let mut it1 = o1.iter_mut();
+
+            for x in i0.iter() {
+                if self.first {
+                    if let Some(d) = it0.next() {
+                        *d = *x;
+                        m0 += 1;
+                    } else {
+                        break;
+                    }
+                } else {
+                    if let Some(d) = it1.next() {
+                        *d = *x;
+                        m1 += 1;
+                    } else {
+                        break;
+                    }
                 }
-                let d = d.expect("");
-                *d = *x;
-                m0 += 1;
-            } else {
-                let d = it1.next();
-                if d.is_none() {
-                    break;
-                }
-                let d = d.expect("");
-                *d = *x;
-                m1 += 1;
+                self.first = !self.first;
             }
-            self.first = !self.first;
-        }
+            (m0 + m1, m0, m1)
+        };
 
-        let m = m0 + m1;
-        sio.input(0).consume(m);
-        sio.output(0).produce(m0);
-        sio.output(1).produce(m1);
+        self.input.consume(m);
+        self.out0.produce(m0);
+        self.out1.produce(m1);
 
-        if sio.input(0).finished() && m == i0.len() {
+        if self.input.finished() && self.input.slice().is_empty() {
             io.finished = true;
         }
 

--- a/src/type_converters.rs
+++ b/src/type_converters.rs
@@ -20,7 +20,7 @@
 //! ```
 //!
 //! Some other conversions are lossy because there is no natural conversion of all possible inputs.
-//! Conversion of `f32` into `i6` is an example because `16.3` has no direct conversion, yet `16` is a good candidate.
+//! Conversion of `f32` into `i16` is an example because `16.3` has no direct conversion, yet `16` is a good candidate.
 //! But `f32` can also represent positive or negative infinity, and NaN (not a number) that are not convertible.
 //!
 //! ```
@@ -31,7 +31,6 @@
 use core::marker::PhantomData;
 
 use futuresdr::blocks::Apply;
-use futuresdr::runtime::Block;
 
 /// Main builder for type conversion blocks
 pub struct TypeConvertersBuilder {}
@@ -96,17 +95,17 @@ impl TypeConvertersBuilder {
 
 impl<A, B> ConverterBuilder<A, B>
 where
-    A: Copy + Send + 'static,
-    B: Copy + Send + From<A> + 'static,
+    A: Copy + Send + Sync + Default + std::fmt::Debug + 'static,
+    B: Copy + Send + Sync + Default + std::fmt::Debug + From<A> + 'static,
 {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &A| -> B { (*i).into() }).into()
+    pub fn build(self) -> Apply<impl FnMut(&A) -> B + Send + 'static, A, B> {
+        Apply::new(|i: &A| -> B { (*i).into() })
     }
 }
 
 impl ScaledConverterBuilder<u8, f32> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &u8| -> f32 { ScaledConverterBuilder::<u8, f32>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&u8) -> f32 + Send + 'static, u8, f32> {
+        Apply::new(|i: &u8| -> f32 { ScaledConverterBuilder::<u8, f32>::convert(i) })
     }
 
     pub fn convert(i: &u8) -> f32 {
@@ -115,8 +114,8 @@ impl ScaledConverterBuilder<u8, f32> {
 }
 
 impl ScaledConverterBuilder<u16, f32> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &u16| -> f32 { ScaledConverterBuilder::<u16, f32>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&u16) -> f32 + Send + 'static, u16, f32> {
+        Apply::new(|i: &u16| -> f32 { ScaledConverterBuilder::<u16, f32>::convert(i) })
     }
 
     pub fn convert(i: &u16) -> f32 {
@@ -125,8 +124,8 @@ impl ScaledConverterBuilder<u16, f32> {
 }
 
 impl ScaledConverterBuilder<u32, f32> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &u32| -> f32 { ScaledConverterBuilder::<u32, f32>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&u32) -> f32 + Send + 'static, u32, f32> {
+        Apply::new(|i: &u32| -> f32 { ScaledConverterBuilder::<u32, f32>::convert(i) })
     }
 
     pub fn convert(i: &u32) -> f32 {
@@ -135,8 +134,8 @@ impl ScaledConverterBuilder<u32, f32> {
 }
 
 impl ScaledConverterBuilder<i8, f32> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &i8| -> f32 { ScaledConverterBuilder::<i8, f32>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&i8) -> f32 + Send + 'static, i8, f32> {
+        Apply::new(|i: &i8| -> f32 { ScaledConverterBuilder::<i8, f32>::convert(i) })
     }
 
     pub fn convert(i: &i8) -> f32 {
@@ -145,8 +144,8 @@ impl ScaledConverterBuilder<i8, f32> {
 }
 
 impl ScaledConverterBuilder<i16, f32> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &i16| -> f32 { ScaledConverterBuilder::<i16, f32>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&i16) -> f32 + Send + 'static, i16, f32> {
+        Apply::new(|i: &i16| -> f32 { ScaledConverterBuilder::<i16, f32>::convert(i) })
     }
 
     pub fn convert(i: &i16) -> f32 {
@@ -155,8 +154,8 @@ impl ScaledConverterBuilder<i16, f32> {
 }
 
 impl ScaledConverterBuilder<i32, f32> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &i32| -> f32 { ScaledConverterBuilder::<i32, f32>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&i32) -> f32 + Send + 'static, i32, f32> {
+        Apply::new(|i: &i32| -> f32 { ScaledConverterBuilder::<i32, f32>::convert(i) })
     }
 
     pub fn convert(i: &i32) -> f32 {
@@ -165,8 +164,8 @@ impl ScaledConverterBuilder<i32, f32> {
 }
 
 impl ScaledConverterBuilder<f32, u8> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &f32| -> u8 { ScaledConverterBuilder::<f32, u8>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&f32) -> u8 + Send + 'static, f32, u8> {
+        Apply::new(|i: &f32| -> u8 { ScaledConverterBuilder::<f32, u8>::convert(i) })
     }
 
     pub fn convert(i: &f32) -> u8 {
@@ -175,8 +174,8 @@ impl ScaledConverterBuilder<f32, u8> {
 }
 
 impl ScaledConverterBuilder<f32, i8> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &f32| -> i8 { ScaledConverterBuilder::<f32, i8>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&f32) -> i8 + Send + 'static, f32, i8> {
+        Apply::new(|i: &f32| -> i8 { ScaledConverterBuilder::<f32, i8>::convert(i) })
     }
 
     pub fn convert(i: &f32) -> i8 {
@@ -185,8 +184,8 @@ impl ScaledConverterBuilder<f32, i8> {
 }
 
 impl ScaledConverterBuilder<f32, i16> {
-    pub fn build(self) -> Block {
-        Apply::new(|i: &f32| -> i16 { ScaledConverterBuilder::<f32, i16>::convert(i) }).into()
+    pub fn build(self) -> Apply<impl FnMut(&f32) -> i16 + Send + 'static, f32, i16> {
+        Apply::new(|i: &f32| -> i16 { ScaledConverterBuilder::<f32, i16>::convert(i) })
     }
 
     pub fn convert(i: &f32) -> i16 {

--- a/tests/async_channel/async_channel_source.rs
+++ b/tests/async_channel/async_channel_source.rs
@@ -25,7 +25,7 @@ async fn async_channel_source_u32() -> Result<()> {
     tx.send(orig.clone().into_boxed_slice()).await.unwrap();
     tx.close();
 
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk = vector_snk.get()?;
     let received = snk.items();

--- a/tests/async_channel/async_channel_source.rs
+++ b/tests/async_channel/async_channel_source.rs
@@ -1,5 +1,5 @@
 use fsdr_blocks::async_channel::AsyncChannelSource;
-use futuresdr::blocks::{Head, VectorSink, VectorSinkBuilder};
+use futuresdr::blocks::{Head, VectorSink};
 use futuresdr::macros::connect;
 use futuresdr::runtime::Result;
 use futuresdr::runtime::{Flowgraph, Runtime};
@@ -16,7 +16,7 @@ async fn async_channel_source_u32() -> Result<()> {
 
     let async_channel_src = AsyncChannelSource::<u32>::new(rx);
     let limit = Head::<u32>::new(orig.len() as u64);
-    let vector_snk = VectorSinkBuilder::<u32>::new().build();
+    let vector_snk = VectorSink::<u32>::new(1024);
 
     connect!(fg,
         async_channel_src > limit > vector_snk;
@@ -27,7 +27,7 @@ async fn async_channel_source_u32() -> Result<()> {
 
     fg = Runtime::new().run(fg)?;
 
-    let snk = fg.kernel::<VectorSink<u32>>(vector_snk).unwrap();
+    let snk = vector_snk.get()?;
     let received = snk.items();
 
     // debug!("{}", received.len());

--- a/tests/channel/crossbeam_source.rs
+++ b/tests/channel/crossbeam_source.rs
@@ -1,5 +1,5 @@
 use fsdr_blocks::channel::CrossbeamSource;
-use futuresdr::blocks::{Head, VectorSink, VectorSinkBuilder};
+use futuresdr::blocks::{Head, VectorSink};
 use futuresdr::macros::connect;
 use futuresdr::runtime::Result;
 use futuresdr::runtime::{Flowgraph, Runtime};
@@ -12,7 +12,7 @@ fn crossbeam_source_u32() -> Result<()> {
 
     let crossbeam_source = CrossbeamSource::<u32>::new(rx);
     let limit = Head::<u32>::new(orig.len() as u64);
-    let vector_sink = VectorSinkBuilder::<u32>::new().build();
+    let vector_sink = VectorSink::<u32>::new(1024);
 
     connect!(fg,
         crossbeam_source > limit > vector_sink;
@@ -22,7 +22,7 @@ fn crossbeam_source_u32() -> Result<()> {
 
     fg = Runtime::new().run(fg)?;
 
-    let snk = fg.kernel::<VectorSink<u32>>(vector_sink).unwrap();
+    let snk = vector_sink.get()?;
     let received = snk.items();
 
     // debug!("{}", received.len());

--- a/tests/channel/crossbeam_source.rs
+++ b/tests/channel/crossbeam_source.rs
@@ -20,7 +20,7 @@ fn crossbeam_source_u32() -> Result<()> {
 
     tx.try_send(orig.clone().into_boxed_slice()).unwrap();
 
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk = vector_sink.get()?;
     let received = snk.items();

--- a/tests/cw/baseband_to_cw.rs
+++ b/tests/cw/baseband_to_cw.rs
@@ -1,7 +1,7 @@
 use fsdr_blocks::cw::baseband_to_cw::BaseBandToCWBuilder;
 use fsdr_blocks::cw::shared::CWAlphabet::*;
 use fsdr_blocks::cw::shared::{char_to_baseband, CWAlphabet};
-use futuresdr::blocks::{VectorSink, VectorSinkBuilder, VectorSource};
+use futuresdr::blocks::{VectorSink, VectorSource};
 use futuresdr::macros::connect;
 use futuresdr::runtime::Result;
 use futuresdr::runtime::{Flowgraph, Runtime};
@@ -21,12 +21,12 @@ fn test_baseband_to_cw() -> Result<()> {
         .collect::<Vec<f32>>();
     println!("BaseBand Vector Length: {}, Content: {:?}", bb.len(), bb);
 
-    let vector_src = VectorSource::new(bb);
+    let vector_src = VectorSource::<f32>::new(bb);
     let baseband_to_cw = BaseBandToCWBuilder::new()
         .accuracy(100)
         .samples_per_dot(samples_per_dot)
         .build();
-    let vector_snk = VectorSinkBuilder::<CWAlphabet>::new().build();
+    let vector_snk = VectorSink::<CWAlphabet>::new(1024);
 
     connect!(fg,
         vector_src > baseband_to_cw > vector_snk;
@@ -34,7 +34,7 @@ fn test_baseband_to_cw() -> Result<()> {
 
     fg = Runtime::new().run(fg)?;
 
-    let snk = fg.kernel::<VectorSink<CWAlphabet>>(vector_snk).unwrap();
+    let snk = vector_snk.get()?;
     let received = snk.items();
 
     println!(

--- a/tests/cw/baseband_to_cw.rs
+++ b/tests/cw/baseband_to_cw.rs
@@ -32,7 +32,7 @@ fn test_baseband_to_cw() -> Result<()> {
         vector_src > baseband_to_cw > vector_snk;
     );
 
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk = vector_snk.get()?;
     let received = snk.items();

--- a/tests/cw/cw_to_char.rs
+++ b/tests/cw/cw_to_char.rs
@@ -26,7 +26,7 @@ fn test_cw_to_char_vector() -> Result<()> {
         cw_to_char > vector_snk;
     );
 
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk = vector_snk.get()?;
     let received: Vec<char> = snk
@@ -61,7 +61,7 @@ fn test_cw_to_char_channel() -> Result<()> {
     );
 
     let rt = Runtime::new();
-    let fg = block_on(async move {
+    let _fg = block_on(async move {
         let (fg, _) = rt.start(fg).await.unwrap();
         let c = msg_to_cw(['S'].as_slice()).into_boxed_slice();
         tx.send(c).await.unwrap();

--- a/tests/cw/cw_to_char.rs
+++ b/tests/cw/cw_to_char.rs
@@ -1,7 +1,7 @@
 use fsdr_blocks::cw::cw_to_char::CWToCharBuilder;
 use fsdr_blocks::cw::shared::{msg_to_cw, CWAlphabet};
 use futuresdr::async_io::block_on;
-use futuresdr::blocks::{ChannelSource, VectorSink, VectorSinkBuilder, VectorSource};
+use futuresdr::blocks::{ChannelSource, VectorSink, VectorSource};
 use futuresdr::futures::SinkExt;
 use futuresdr::macros::connect;
 use futuresdr::runtime::Result;
@@ -17,9 +17,9 @@ fn test_cw_to_char_vector() -> Result<()> {
     let cw = msg_to_cw(message.as_slice());
     //println!("CW-Alphabet Vector Length: {}, Content: {:?}", cw.len(), cw);
 
-    let vector_src = VectorSource::new(cw);
+    let vector_src = VectorSource::<CWAlphabet>::new(cw);
     let cw_to_char = CWToCharBuilder::new().build();
-    let vector_snk = VectorSinkBuilder::<char>::new().build();
+    let vector_snk = VectorSink::<u32>::new(1024);
 
     connect!(fg,
         vector_src > cw_to_char;
@@ -28,15 +28,19 @@ fn test_cw_to_char_vector() -> Result<()> {
 
     fg = Runtime::new().run(fg)?;
 
-    let snk = fg.kernel::<VectorSink<char>>(vector_snk).unwrap();
-    let received = snk.items();
+    let snk = vector_snk.get()?;
+    let received: Vec<char> = snk
+        .items()
+        .iter()
+        .map(|&c| char::from_u32(c).unwrap_or('_'))
+        .collect();
 
     /*println!(
         "Char Vector Length: {}, Content: {:?}",
         received.len(),
         received
     );*/
-    assert_eq!(&vec!['S', ' ', 'O', '_', ' ', ' ', 'S'], received);
+    assert_eq!(vec!['S', ' ', 'O', '_', ' ', ' ', 'S'], received);
 
     Ok(())
 }
@@ -50,7 +54,7 @@ fn test_cw_to_char_channel() -> Result<()> {
 
     let channel_src = ChannelSource::<CWAlphabet>::new(rx);
     let cw_to_char = CWToCharBuilder::new().build();
-    let vector_snk = VectorSinkBuilder::<char>::new().build();
+    let vector_snk = VectorSink::<u32>::new(1024);
 
     connect!(fg,
         channel_src > cw_to_char > vector_snk;
@@ -58,7 +62,7 @@ fn test_cw_to_char_channel() -> Result<()> {
 
     let rt = Runtime::new();
     let fg = block_on(async move {
-        let (fg, _) = rt.start(fg).await;
+        let (fg, _) = rt.start(fg).await.unwrap();
         let c = msg_to_cw(['S'].as_slice()).into_boxed_slice();
         tx.send(c).await.unwrap();
         let c = msg_to_cw([' '].as_slice()).into_boxed_slice();
@@ -75,15 +79,19 @@ fn test_cw_to_char_channel() -> Result<()> {
         fg.await // as Result<Flowgraph>
     })?;
 
-    let snk = fg.kernel::<VectorSink<char>>(vector_snk).unwrap();
-    let received = snk.items();
+    let snk = vector_snk.get()?;
+    let received: Vec<char> = snk
+        .items()
+        .iter()
+        .map(|&c| char::from_u32(c).unwrap_or('_'))
+        .collect();
 
     /*println!(
         "Char Vector Length: {}, Content: {:?}",
         received.len(),
         received
     );*/
-    assert_eq!(&vec!['S', ' ', 'O', '_', 'S'], received);
+    assert_eq!(vec!['S', ' ', 'O', '_', 'S'], received);
 
     Ok(())
 }

--- a/tests/math/freq_shift.rs
+++ b/tests/math/freq_shift.rs
@@ -20,7 +20,7 @@ fn freq_shift_f32() -> Result<()> {
     connect!(fg,
         src > freq_shifter > vect_sink;
     );
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk_0 = vect_sink.get()?;
     let snk_0 = snk_0.items();
@@ -68,7 +68,7 @@ fn freq_shift_c32() -> Result<()> {
     connect!(fg,
         src > freq_shifter > vect_sink;
     );
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk_0 = vect_sink.get()?;
     let snk_0 = snk_0.items();

--- a/tests/math/freq_shift.rs
+++ b/tests/math/freq_shift.rs
@@ -1,6 +1,5 @@
 use fsdr_blocks::math::FrequencyShifter;
 use futuresdr::blocks::VectorSink;
-use futuresdr::blocks::VectorSinkBuilder;
 use futuresdr::blocks::VectorSource;
 use futuresdr::macros::connect;
 use futuresdr::num_complex::Complex32;
@@ -16,14 +15,14 @@ fn freq_shift_f32() -> Result<()> {
 
     let orig: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
     let src = VectorSource::<f32>::new(orig.clone());
-    let vect_sink = VectorSinkBuilder::<f32>::new().build();
+    let vect_sink = VectorSink::<f32>::new(1024);
 
     connect!(fg,
         src > freq_shifter > vect_sink;
     );
     fg = Runtime::new().run(fg)?;
 
-    let snk_0 = fg.kernel::<VectorSink<f32>>(vect_sink).unwrap();
+    let snk_0 = vect_sink.get()?;
     let snk_0 = snk_0.items();
 
     assert_eq!(snk_0.len(), orig.len());
@@ -64,20 +63,20 @@ fn freq_shift_c32() -> Result<()> {
     let expected = expected;
 
     let src = VectorSource::<Complex32>::new(orig.clone());
-    let vect_sink = VectorSinkBuilder::<Complex32>::new().build();
+    let vect_sink = VectorSink::<Complex32>::new(1024);
 
     connect!(fg,
         src > freq_shifter > vect_sink;
     );
     fg = Runtime::new().run(fg)?;
 
-    let snk_0 = fg.kernel::<VectorSink<Complex32>>(vect_sink).unwrap();
+    let snk_0 = vect_sink.get()?;
     let snk_0 = snk_0.items();
 
     assert_eq!(snk_0.len(), orig.len());
     for (i, (v, e)) in snk_0.iter().zip(expected.iter()).enumerate() {
         assert!(
-            (v - e).norm() < 0.000000001,
+            (v - e).norm() < 0.00001,
             "Equality expected. actual[{i}]: {v}, expected[{i}]: {e}"
         );
     }

--- a/tests/sigmf/sigmf_graph.rs
+++ b/tests/sigmf/sigmf_graph.rs
@@ -1,8 +1,6 @@
-use futuresdr::blocks::VectorSink;
-
 use fsdr_blocks::sigmf::{BytesConveter, SigMFSink, SigMFSourceBuilder};
 use futuresdr::{
-    blocks::{VectorSinkBuilder, VectorSource},
+    blocks::{VectorSink, VectorSource},
     macros::connect,
     runtime::Result,
     runtime::{Flowgraph, Runtime},
@@ -23,12 +21,13 @@ where
         + std::marker::Send
         + std::marker::Sync
         + std::fmt::Debug
+        + std::default::Default
         + std::cmp::PartialEq,
     DatasetFormat: BytesConveter<T>,
 {
     let mut fg = Flowgraph::new();
 
-    let src1 = VectorSource::new(data.clone());
+    let src1 = VectorSource::<T>::new(data.clone());
     let data_file_content: Vec<u8> = vec![];
     let meta_file_content: Vec<u8> = vec![];
     let data_file = std::io::Cursor::new(data_file_content);
@@ -39,9 +38,7 @@ where
         src1 > snk1;
     );
     fg = Runtime::new().run(fg)?;
-    let snk1 = fg
-        .kernel::<SigMFSink<T, std::io::Cursor<Vec<u8>>, std::io::Cursor<Vec<u8>>>>(snk1)
-        .unwrap();
+    let snk1 = snk1.get()?;
     let desc = snk1.description.build()?;
     let mut fg = Flowgraph::new();
     let data_file = snk1.writer.to_owned().into_inner();
@@ -49,15 +46,15 @@ where
     let src2 = futuresdr::futures::executor::block_on(
         SigMFSourceBuilder::with_data_and_description(data_file, desc).build::<T>(),
     )?;
-    let snk2 = VectorSinkBuilder::<T>::new().build();
+    let snk2 = VectorSink::<T>::new(1024);
     connect!(fg,
         src2 > snk2;
     );
     fg = Runtime::new().run(fg)?;
-    let snk2 = fg.kernel::<VectorSink<T>>(snk2).unwrap().items();
+    let snk2 = snk2.get()?.items().clone();
     assert_eq!(data.len(), snk2.len());
     for (o, i) in data.iter().zip(snk2) {
-        assert_eq!(*o, *i);
+        assert_eq!(o, &i);
     }
     Ok(())
 }
@@ -122,9 +119,7 @@ fn sigmf_read_write_annotation() -> Result<()> {
     fg = Runtime::new().run(fg)?;
 
     // Time to verify
-    let snk1 = fg
-        .kernel::<SigMFSink<u8, std::io::Cursor<Vec<u8>>, std::io::Cursor<Vec<u8>>>>(snk1)
-        .unwrap();
+    let snk1 = snk1.get()?;
     let tgt_desc = snk1.description.build()?;
     let annotations = tgt_desc.annotations()?;
     assert_eq!(2, annotations.len());

--- a/tests/sigmf/sigmf_graph.rs
+++ b/tests/sigmf/sigmf_graph.rs
@@ -37,7 +37,7 @@ where
     connect!(fg,
         src1 > snk1;
     );
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
     let snk1 = snk1.get()?;
     let desc = snk1.description.build()?;
     let mut fg = Flowgraph::new();
@@ -50,7 +50,7 @@ where
     connect!(fg,
         src2 > snk2;
     );
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
     let snk2 = snk2.get()?.items().clone();
     assert_eq!(data.len(), snk2.len());
     for (o, i) in data.iter().zip(snk2) {
@@ -116,7 +116,7 @@ fn sigmf_read_write_annotation() -> Result<()> {
         src1 > snk1;
     );
     // Now run the flowgraph
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     // Time to verify
     let snk1 = snk1.get()?;

--- a/tests/sigmf/sigmf_source.rs
+++ b/tests/sigmf/sigmf_source.rs
@@ -1,7 +1,6 @@
 use fsdr_blocks::sigmf::BytesConveter;
 use fsdr_blocks::sigmf::SigMFSourceBuilder;
 use futuresdr::blocks::VectorSink;
-use futuresdr::blocks::VectorSinkBuilder;
 use futuresdr::futures::io::BufReader;
 use futuresdr::futures::io::Cursor;
 use futuresdr::macros::connect;
@@ -19,6 +18,7 @@ where
         + std::marker::Sync
         + std::marker::Copy
         + std::fmt::Debug
+        + std::default::Default
         + 'static,
     DatasetFormat: BytesConveter<T>,
 {
@@ -30,7 +30,7 @@ where
     let src = futuresdr::futures::executor::block_on(
         SigMFSourceBuilder::with_data_and_description(actual_file, desc).build::<T>(),
     )?;
-    let snk = VectorSinkBuilder::<T>::new().build();
+    let snk = VectorSink::<T>::new(1024);
 
     connect!(fg,
         src > snk;
@@ -38,7 +38,7 @@ where
 
     fg = Runtime::new().run(fg)?;
 
-    let snk = fg.kernel::<VectorSink<T>>(snk).unwrap();
+    let snk = snk.get()?;
     Ok(snk.items().clone())
 }
 

--- a/tests/sigmf/sigmf_source.rs
+++ b/tests/sigmf/sigmf_source.rs
@@ -36,7 +36,7 @@ where
         src > snk;
     );
 
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk = snk.get()?;
     Ok(snk.items().clone())

--- a/tests/stream/deinterleave.rs
+++ b/tests/stream/deinterleave.rs
@@ -1,6 +1,5 @@
 use fsdr_blocks::stream::*;
 use futuresdr::blocks::VectorSink;
-use futuresdr::blocks::VectorSinkBuilder;
 use futuresdr::blocks::VectorSource;
 use futuresdr::macros::connect;
 use futuresdr::runtime::Flowgraph;
@@ -15,8 +14,8 @@ fn deinterleave_u8() -> Result<()> {
 
     let orig: Vec<u8> = vec![0, 1, 0, 1, 0, 1, 0, 1, 0, 1];
     let src = VectorSource::<u8>::new(orig.clone());
-    let vect_sink_0 = VectorSinkBuilder::<u8>::new().build();
-    let vect_sink_1 = VectorSinkBuilder::<u8>::new().build();
+    let vect_sink_0 = VectorSink::<u8>::new(1024);
+    let vect_sink_1 = VectorSink::<u8>::new(1024);
 
     connect!(fg,
         src > deinterleaver;
@@ -25,10 +24,10 @@ fn deinterleave_u8() -> Result<()> {
     );
     fg = Runtime::new().run(fg)?;
 
-    let snk_0 = fg.kernel::<VectorSink<u8>>(vect_sink_0).unwrap();
+    let snk_0 = vect_sink_0.get()?;
     let snk_0 = snk_0.items();
 
-    let snk_1 = fg.kernel::<VectorSink<u8>>(vect_sink_1).unwrap();
+    let snk_1 = vect_sink_1.get()?;
     let snk_1 = snk_1.items();
 
     assert_eq!(snk_0.len(), orig.len() / 2);

--- a/tests/stream/deinterleave.rs
+++ b/tests/stream/deinterleave.rs
@@ -22,7 +22,7 @@ fn deinterleave_u8() -> Result<()> {
         deinterleaver.out0 > vect_sink_0;
         deinterleaver.out1 > vect_sink_1;
     );
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk_0 = vect_sink_0.get()?;
     let snk_0 = snk_0.items();

--- a/tests/type_converters.rs
+++ b/tests/type_converters.rs
@@ -1,6 +1,5 @@
 use fsdr_blocks::type_converters::*;
 use futuresdr::blocks::VectorSink;
-use futuresdr::blocks::VectorSinkBuilder;
 use futuresdr::blocks::VectorSource;
 use futuresdr::macros::connect;
 use futuresdr::runtime::Flowgraph;
@@ -15,14 +14,14 @@ fn convert_u8_f32() -> Result<()> {
 
     let orig: Vec<u8> = vec![1, 0, 255, 42, 53, 89, 75];
     let src = VectorSource::<u8>::new(orig.clone());
-    let vect_sink = VectorSinkBuilder::<f32>::new().build();
+    let vect_sink = VectorSink::<f32>::new(1024);
 
     connect!(fg,
         src > convert_u8_f32 > vect_sink;
     );
     fg = Runtime::new().run(fg)?;
 
-    let snk = fg.kernel::<VectorSink<f32>>(vect_sink).unwrap();
+    let snk = vect_sink.get()?;
     let v = snk.items();
 
     assert_eq!(v.len(), orig.len());
@@ -44,14 +43,14 @@ fn convert_u8_f32() -> Result<()> {
 
 //     let orig: Vec<u8> = vec![1, 0, 255, 42, 53, 89, 75];
 //     let src = VectorSource::<u8>::new(orig.clone());
-//     let vect_sink = VectorSinkBuilder::<f32>::new().build();
+//     let vect_sink = VectorSink::<f32>::new(1024);
 
 //     connect!(fg,
 //         src > convert_u8_f32 > vect_sink;
 //     );
 //     fg = Runtime::new().run(fg)?;
 
-//     let snk = fg.kernel::<VectorSink<f32>>(vect_sink).unwrap();
+//     let snk = vect_sink.get()?;
 //     let v = snk.items();
 
 //     assert_eq!(v.len(), orig.len());

--- a/tests/type_converters.rs
+++ b/tests/type_converters.rs
@@ -19,7 +19,7 @@ fn convert_u8_f32() -> Result<()> {
     connect!(fg,
         src > convert_u8_f32 > vect_sink;
     );
-    fg = Runtime::new().run(fg)?;
+    Runtime::new().run(fg)?;
 
     let snk = vect_sink.get()?;
     let v = snk.items();
@@ -48,7 +48,7 @@ fn convert_u8_f32() -> Result<()> {
 //     connect!(fg,
 //         src > convert_u8_f32 > vect_sink;
 //     );
-//     fg = Runtime::new().run(fg)?;
+//     Runtime::new().run(fg)?;
 
 //     let snk = vect_sink.get()?;
 //     let v = snk.items();


### PR DESCRIPTION
Automatically migrate all blocks to latest `0.0.40-dev` API.
Tests and  Clippy are passing.